### PR TITLE
Apply new style for register

### DIFF
--- a/src/inferenceql/viz/components/query/events.cljs
+++ b/src/inferenceql/viz/components/query/events.cljs
@@ -79,11 +79,13 @@
         {:js/console-error error-log-msg
          :js/alert alert-msg}))))
 
-(defn ^:event-fx parse-query
+(defn parse-query
   "Executes the query represented by `text` on the default dataset and model.
 
   Query execution may happen locally or remotely depending on whether the :query-server-url key is
   present in the app config.
+
+  To be used as a re-frame event-fx.
 
   Triggered when:
     The user presses enter in the query text box or when the `Run InferenceQL` button is pressed.
@@ -116,13 +118,15 @@
       (let [rows (->> (get-in datasets [:data :rows])
                       (map #(medley/remove-vals nil? %)))]
         (execute-query-locally query rows models)))))
-(rf/reg-event-fx
-  :query/parse-query
-  event-interceptors
-  parse-query)
 
-(defn ^:event-fx post-success
+(rf/reg-event-fx :query/parse-query
+                 event-interceptors
+                 parse-query)
+
+(defn post-success
   "Uses the successful response from the query webserver to display query results.
+
+  To be used as a re-frame event-fx.
 
   Triggered when:
     When the http-xhrio request in :query/parse-query returns successfully.
@@ -137,10 +141,10 @@
         {columns :iql/columns} metadata]
     {:fx [[:dispatch [:table/set result-rows columns {:virtual false}]]
           [:dispatch [:query/set-details query]]]}))
-(rf/reg-event-fx
-  :query/post-success
-  event-interceptors
-  post-success)
+
+(rf/reg-event-fx :query/post-success
+                 event-interceptors
+                 post-success)
 
 (defn ^:event-fx post-failure
   "Uses the failure response from the query webserver or cljs-ajax to display error messages.
@@ -171,10 +175,10 @@
         {:keys [error-log-msg alert-msg]} (merge default-errors errors)]
     {:js/console-error error-log-msg
      :js/alert alert-msg}))
-(rf/reg-event-fx
-  :query/post-failure
-  event-interceptors
-  post-failure)
+
+(rf/reg-event-fx :query/post-failure
+                 event-interceptors
+                 post-failure)
 
 (defn ^:event-db set-details
   "Stores additional information extracted from `query`.
@@ -191,7 +195,7 @@
   (-> db
       (assoc-in [:query-component :column-details] (util/column-details query))
       (assoc-in [:query-component :virtual] (util/virtual-data? query))))
-(rf/reg-event-db
-  :query/set-details
-  event-interceptors
-  set-details)
+
+(rf/reg-event-db :query/set-details
+                 event-interceptors
+                 set-details)

--- a/src/inferenceql/viz/components/query/subs.cljs
+++ b/src/inferenceql/viz/components/query/subs.cljs
@@ -26,40 +26,40 @@
   "Returns the dataset referenced in the query text."
   [[dataset-name datasets]]
   (get datasets dataset-name))
-(rf/reg-sub
-  :query/dataset
-  :<- [:query/dataset-name]
-  :<- [:store/datasets]
-  dataset)
+
+(rf/reg-sub :query/dataset
+            :<- [:query/dataset-name]
+            :<- [:store/datasets]
+            dataset)
 
 (defn ^:sub geo-id-col
   "Returns the geo-id-col associated with the dataset referenced in the query text."
   [dataset]
   (keyword (:geo-id-col dataset)))
-(rf/reg-sub
-  :query/geo-id-col
-  :<- [:query/dataset]
-  geo-id-col)
+
+(rf/reg-sub :query/geo-id-col
+            :<- [:query/dataset]
+            geo-id-col)
 
 (defn ^:sub geodata
   "Returns the geodata associated with the dataset referenced in the query text."
   [[dataset geodata]]
   (get geodata (:geodata-name dataset)))
-(rf/reg-sub
-  :query/geodata
-  :<- [:query/dataset]
-  :<- [:store/geodata]
-  geodata)
+
+(rf/reg-sub :query/geodata
+            :<- [:query/dataset]
+            :<- [:store/geodata]
+            geodata)
 
 (defn ^:sub model
   "Returns the model referenced in the query text."
   [[model-name models]]
   (get models model-name))
-(rf/reg-sub
-  :query/model
-  :<- [:query/model-name]
-  :<- [:store/models]
-  model)
+
+(rf/reg-sub :query/model
+            :<- [:query/model-name]
+            :<- [:store/models]
+            model)
 
 (defn ^:sub simulatable-cols
   "Returns a set of column names that are simulatable.
@@ -71,10 +71,10 @@
       (:schema)
       (keys)
       (set)))
-(rf/reg-sub
-  :query/simulatable-cols
-  :<- [:query/dataset]
-  simulatable-cols)
+
+(rf/reg-sub :query/simulatable-cols
+            :<- [:query/dataset]
+            simulatable-cols)
 
 (defn ^:sub column-renames
   "Returns a map of columns that have been renamed as a result of executing the last query.
@@ -86,10 +86,10 @@
        (filter #(= (:detail-type %) :rename))
        (map (juxt :old-name :new-name))
        (into {})))
-(rf/reg-sub
-  :query/column-renames
-  :<- [:query/column-details]
-  column-renames)
+
+(rf/reg-sub :query/column-renames
+            :<- [:query/column-details]
+            column-renames)
 
 (defn ^:sub new-columns-schema
   "Returns a schema for new columns that were created as a result of executing the last query.
@@ -100,10 +100,10 @@
        (filter #(= (:detail-type %) :new-column-schema))
        (map (juxt :name :stat-type))
        (into {})))
-(rf/reg-sub
-  :query/new-columns-schema
-  :<- [:query/column-details]
-  new-columns-schema)
+
+(rf/reg-sub :query/new-columns-schema
+            :<- [:query/column-details]
+            new-columns-schema)
 
 (defn ^:sub schema
   "Returns a schema for the query whose results are currently displayed.
@@ -114,9 +114,9 @@
   (let [schema (:schema dataset)
         schema-with-renames (medley/map-keys #(get column-renames % %) schema)]
     (merge new-columns-schema schema-with-renames)))
-(rf/reg-sub
-  :query/schema
-  :<- [:query/dataset]
-  :<- [:query/column-renames]
-  :<- [:query/new-columns-schema]
-  schema)
+
+(rf/reg-sub :query/schema
+            :<- [:query/dataset]
+            :<- [:query/column-renames]
+            :<- [:query/new-columns-schema]
+            schema)


### PR DESCRIPTION
Proposing a new way to style reframe register calls when the function being registered is defined separately.

* One space between `register-xxx` and the previous definition of the function.
* First argument to `register-xxx` is on the same line. 
* All other arguments are indented to be inline with the first argument. 

I have found this creates the better readability.

Note: I will move the removal of function annotations to an other PR.

Note: I will extend this restyling to more files when after this is reviewed. 