### PR TITLE
Move events that correspond to hot hooks

### DIFF
--- a/src/inferenceql/viz/core.cljs
+++ b/src/inferenceql/viz/core.cljs
@@ -17,6 +17,7 @@
             ;; Table Panel
             [inferenceql.viz.panels.table.events]
             [inferenceql.viz.panels.table.subs]
+            [inferenceql.viz.panels.table.handsontable-events]
             ;; More Panel
             [inferenceql.viz.panels.more.events]
             [inferenceql.viz.panels.more.subs]

--- a/src/inferenceql/viz/panels/table/events.cljs
+++ b/src/inferenceql/viz/panels/table/events.cljs
@@ -1,13 +1,10 @@
 (ns inferenceql.viz.panels.table.events
+  "Re-frame events related to data and selections in Handsontable"
   (:require [re-frame.core :as rf]
             [inferenceql.viz.panels.table.db :as db]
-            [inferenceql.viz.panels.table.handsontable :as hot]
-            [inferenceql.viz.panels.table.selections :as selections]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
             [inferenceql.viz.panels.control.db :as control-db]
             [inferenceql.viz.util :as util]))
-
-;;; Events that do not correspond to hooks in the Handsontable api.
 
 (rf/reg-event-fx
  :table/set
@@ -71,74 +68,3 @@
 
        :else
        db))))
-
-;;; Events that correspond to hooks in the Handsontable API
-
-(rf/reg-event-fx
- :hot/after-selection-end
- event-interceptors
- (fn [{:keys [db]} [_ hot id row-index _col _row2 _col2 _selection-layer-level]]
-   (let [selection-coords (selections/normalize (js->clj (.getSelected hot)))
-         color (control-db/selection-color db)]
-     {:db (assoc-in db [:table-panel :selection-layers color :coords] selection-coords)
-      :dispatch [:table/check-selection]})))
-
-(rf/reg-event-db
- :hot/after-on-cell-mouse-down
- event-interceptors
- (fn [db [_ hot id mouse-event coords _TD]]
-   (let [;; Stores whether the user clicked on one of the column headers.
-         header-clicked-flag (= -1 (.-row coords))
-
-         ;; Stores whether the user held alt during the click.
-         alt-key-pressed (.-altKey mouse-event)
-         color (control-db/selection-color db)]
-
-     (if alt-key-pressed
-       ; Deselect all cells in selection layer on alt-click.
-       (update-in db [:table-panel :selection-layers] dissoc color)
-       ;; Otherwise just save whether a header was clicked or not.
-       (assoc-in db [:table-panel :selection-layers color :header-clicked] header-clicked-flag)))))
-
-(defn assoc-visual-headers
-  "Associates the column headers as displayed by `hot` into `db`.
-  This data changes when the user re-orders columns.
-  We use this data to along with selection coordinates to produce the data subset selected.
-  This all eventually gets passed onto the visualization code via subscriptions."
-  [db hot]
-  (let [headers (mapv keyword (js->clj (.getColHeader hot)))]
-    (assoc-in db [:table-panel :visual-headers] headers)))
-
-(defn assoc-visual-row-data
-  "Associates the actual row data as displayed by `hot` into `db`.
-  The data changes when the user filters or sorts columns.
-  We use this data to along with selection coordinates to produce the data subset selected.
-  This all eventually gets passed onto the visualization code via subscriptions."
-  [db hot]
-  (let [raw-rows (js->clj (.getData hot))
-        rows (for [r raw-rows]
-               (let [remove-nan (fn [cell] (when-not (js/Number.isNaN cell) cell))]
-                 (mapv remove-nan r)))
-        headers (mapv keyword (js->clj (.getColHeader hot)))
-        row-maps (mapv #(zipmap headers %) rows)]
-    (assoc-in db [:table-panel :visual-rows] row-maps)))
-
-(rf/reg-event-db
- :hot/after-column-move
- event-interceptors
- (fn [db [_ hot _id _moved-columns _final-index _drop-index _move-possible _order-changed]]
-   (assoc-visual-headers db hot)))
-
-(rf/reg-event-db
- :hot/after-column-sort
- event-interceptors
- (fn [db [_ hot _id _current-sort-config _destination-sort-config]]
-   (-> db
-       (assoc-visual-row-data hot)
-       (assoc-visual-headers hot))))
-
-(rf/reg-event-db
- :hot/after-filter
- event-interceptors
- (fn [db [_ hot _id _conditions-stack]]
-   (assoc-visual-row-data db hot)))

--- a/src/inferenceql/viz/panels/table/handsontable_events.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable_events.cljs
@@ -1,0 +1,75 @@
+(ns inferenceql.viz.panels.table.handsontable-events
+  "Re-frame events that correspond to hooks in Handsontable."
+  (:require [re-frame.core :as rf]
+            [inferenceql.viz.panels.table.selections :as selections]
+            [inferenceql.viz.events.interceptors :refer [event-interceptors]]
+            [inferenceql.viz.panels.control.db :as control-db]))
+
+(rf/reg-event-fx
+ :hot/after-selection-end
+ event-interceptors
+ (fn [{:keys [db]} [_ hot id row-index _col _row2 _col2 _selection-layer-level]]
+   (let [selection-coords (selections/normalize (js->clj (.getSelected hot)))
+         color (control-db/selection-color db)]
+     {:db (assoc-in db [:table-panel :selection-layers color :coords] selection-coords)
+      :dispatch [:table/check-selection]})))
+
+(rf/reg-event-db
+ :hot/after-on-cell-mouse-down
+ event-interceptors
+ (fn [db [_ hot id mouse-event coords _TD]]
+   (let [;; Stores whether the user clicked on one of the column headers.
+         header-clicked-flag (= -1 (.-row coords))
+
+         ;; Stores whether the user held alt during the click.
+         alt-key-pressed (.-altKey mouse-event)
+         color (control-db/selection-color db)]
+
+     (if alt-key-pressed
+       ; Deselect all cells in selection layer on alt-click.
+       (update-in db [:table-panel :selection-layers] dissoc color)
+       ;; Otherwise just save whether a header was clicked or not.
+       (assoc-in db [:table-panel :selection-layers color :header-clicked] header-clicked-flag)))))
+
+(defn assoc-visual-headers
+  "Associates the column headers as displayed by `hot` into `db`.
+  This data changes when the user re-orders columns.
+  We use this data to along with selection coordinates to produce the data subset selected.
+  This all eventually gets passed onto the visualization code via subscriptions."
+  [db hot]
+  (let [headers (mapv keyword (js->clj (.getColHeader hot)))]
+    (assoc-in db [:table-panel :visual-headers] headers)))
+
+(defn assoc-visual-row-data
+  "Associates the actual row data as displayed by `hot` into `db`.
+  The data changes when the user filters or sorts columns.
+  We use this data to along with selection coordinates to produce the data subset selected.
+  This all eventually gets passed onto the visualization code via subscriptions."
+  [db hot]
+  (let [raw-rows (js->clj (.getData hot))
+        rows (for [r raw-rows]
+               (let [remove-nan (fn [cell] (when-not (js/Number.isNaN cell) cell))]
+                 (mapv remove-nan r)))
+        headers (mapv keyword (js->clj (.getColHeader hot)))
+        row-maps (mapv #(zipmap headers %) rows)]
+    (assoc-in db [:table-panel :visual-rows] row-maps)))
+
+(rf/reg-event-db
+ :hot/after-column-move
+ event-interceptors
+ (fn [db [_ hot _id _moved-columns _final-index _drop-index _move-possible _order-changed]]
+   (assoc-visual-headers db hot)))
+
+(rf/reg-event-db
+ :hot/after-column-sort
+ event-interceptors
+ (fn [db [_ hot _id _current-sort-config _destination-sort-config]]
+   (-> db
+       (assoc-visual-row-data hot)
+       (assoc-visual-headers hot))))
+
+(rf/reg-event-db
+ :hot/after-filter
+ event-interceptors
+ (fn [db [_ hot _id _conditions-stack]]
+   (assoc-visual-row-data db hot)))


### PR DESCRIPTION
This moves events that correspond to handsontable hooks to their own file.

Motivation: This will make them more easy to distinguish for other table related events. 