### PR TITLE
Fix kaocha cljs tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
  :aliases {:test {:extra-paths ["test"
                                 "test-resources"]
                   :extra-deps {org.clojure/test.check {:mvn/version "0.10.0"}
-                               lambdaisland/kaocha {:mvn/version "1.0.732"}
+                               lambdaisland/kaocha {:mvn/version "1.0-612"}
                                lambdaisland/kaocha-cljs {:mvn/version "0.0-71"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}}}
            :figwheel {:extra-paths ["figwheel-target"]

--- a/tests.edn
+++ b/tests.edn
@@ -4,6 +4,6 @@
           :test-paths ["test"]}
          {:id :viz-cljs
           :type :kaocha.type/cljs
-          :cljs/timeout 20000
+          :cljs/timeout 60000
           :source-paths ["src"]
           :test-paths ["test"]}]}


### PR DESCRIPTION
## What does this  do?

* Increases the timeout for kaocha cljs tests to 60s
* Switches the version of the `kaocha` dep to a version that seems to be consistently working for cljs tests in `iql.query`. (Note: both iql.viz and iql.quey are using the same version of the `kachoa-cljs` dep)

Motivation: Testing seems to fail intermitently with a "Failed initializing
ClojureScript runtime" error. Increasing the this timeout and switching kaocha version  may improve this.
