### PR TITLE
Store handsontable instance in db

### DIFF
--- a/src/inferenceql/viz/panels/table/db.cljs
+++ b/src/inferenceql/viz/panels/table/db.cljs
@@ -9,7 +9,8 @@
                                       ::rows
                                       ::visual-headers
                                       ::visual-rows
-                                      ::virtual]))
+                                      ::virtual
+                                      ::hot-instance]))
 
 ;;; Specs related to table data.
 
@@ -34,6 +35,10 @@
 
 (s/def ::selection-color #{:blue :red :green})
 (s/def ::selection-layer-coords (s/map-of ::selection-color ::coords-seq))
+
+;;; Spec related to the handsontable instance itself.
+
+(s/def ::hot-instance some?)
 
 ;;; Accessor functions to portions of the table-panel db.
 

--- a/src/inferenceql/viz/panels/table/events.cljs
+++ b/src/inferenceql/viz/panels/table/events.cljs
@@ -68,3 +68,21 @@
 
        :else
        db))))
+
+(defn set-hot-instance
+  "To be used as re-frame event-db."
+  [db [_ hot-instance]]
+  (assoc-in db [:table-panel :hot-instance] hot-instance))
+
+(rf/reg-event-db :table/set-hot-instance
+                 event-interceptors
+                 set-hot-instance)
+
+(defn unset-hot-instance
+  "To be used as re-frame event-db."
+  [db _]
+  (update-in db [:table-panel] dissoc :hot-instance))
+
+(rf/reg-event-db :table/unset-hot-instance
+                 event-interceptors
+                 unset-hot-instance)

--- a/src/inferenceql/viz/panels/table/subs.cljs
+++ b/src/inferenceql/viz/panels/table/subs.cljs
@@ -230,3 +230,12 @@
      :cells-missing
      (fn [& args]
        (rends/missing-cell-wise-likelihood-threshold-renderer args missing-cells-flagged computed-headers)))))
+
+(defn hot-instance
+  "Returns the instance of Handsontable used to display the table.
+  To be used as a re-frame subscription."
+  [db _]
+  (get-in db [:table-panel :hot-instance]))
+
+(rf/reg-sub :table/hot-instance
+            hot-instance)


### PR DESCRIPTION
### What does this do?

Saves the instance of Handsonable created within the table reagent component in the app-db.

### Motivation

For upcoming UI changes for few-shot learning. 

New re-frame effects will be added that call functions on the Handsonable instance.

For example: refreshing, mutating table data, etc. 
