### PR TITLE
Improve smoothness of cross highlighting interactions

### DIFF
--- a/src/inferenceql/viz/panels/viz/db.cljs
+++ b/src/inferenceql/viz/panels/viz/db.cljs
@@ -6,7 +6,8 @@
 (def default-db
   {:viz-panel {}})
 
-(s/def ::viz-panel (s/keys :opt-un [::pts-store]))
+(s/def ::viz-panel (s/keys :opt-un [::pts-store
+                                    ::pts-store-staged]))
 
 ;; This holds the vega dataset, "pts-store".
 ;; This dataset corresponds to the vega-lite selection named "pts".
@@ -14,6 +15,10 @@
 ;; See for more info: https://github.com/vega/vega-lite/issues/1830
 ;; We use this to store data representing the selections within vega-lite plots.
 (s/def ::pts-store (s/coll-of ::store-elem))
+
+;; This is a staged value for ::pts-store
+(s/def ::pts-store-staged (s/coll-of ::store-elem))
+
 (s/def ::store-elem (s/keys :req-un [::fields
                                      ::values]))
 

--- a/src/inferenceql/viz/panels/viz/events.cljs
+++ b/src/inferenceql/viz/panels/viz/events.cljs
@@ -7,8 +7,16 @@
   :viz/set-pts-store
   event-interceptors
   (fn [db [_ new-val]]
+    (if-let [staged-val (get-in db [:viz-panel :pts-store-staged])]
+      (assoc-in db [:viz-panel :pts-store] staged-val)
+      (update-in db [:viz-panel] dissoc :pts-store))))
+
+(rf/reg-event-db
+  :viz/stage-pts-store
+  event-interceptors
+  (fn [db [_ new-val]]
       (let [new-pts-store (js->clj new-val :keywordize-keys true)
-            cleaned-pts-store (when new-pts-store
+            cleaned-pts-store (when (seq new-pts-store)
                                 (for [store-elem new-pts-store]
                                   ;; Remove the "getter" attribute in all of the field maps in this `store-elem`.
                                   ;; The "getter" attribute is a function added by vega that we don't need to save.
@@ -17,7 +25,9 @@
                                   ;; when in fact only this "getter" attribute has changed.
                                   (let [clean-fields (fn [fields] (mapv #(dissoc % :getter) fields))]
                                     (update store-elem :fields clean-fields))))]
-        (assoc-in db [:viz-panel :pts-store] cleaned-pts-store))))
+        (if cleaned-pts-store
+          (assoc-in db [:viz-panel :pts-store-staged] cleaned-pts-store)
+          (update-in db [:viz-panel] dissoc :pts-store-staged)))))
 
 (rf/reg-event-db
   :viz/clear-pts-store


### PR DESCRIPTION
## What does this do?

It adds a new event `:viz/stage-pts-store`, which allows users to click and drag out new selections in vega-lite visualizations with out triggering handsonable to highlight the selected rows. 

Rows only get highlighted when the user releases the mouse button after dragging out the selection. (via the previously used `:viz/set-pts-store` event)

Previously if the user was dragging out a selection and paused for a moment, a call to `:viz/set-pts-store` would fire triggering the table to update highlighted rows, resulting in a laggy experience. This update now only happens when the selection in the vega-lite plot is completed with the mouse lift.

A separate listener has also been added to handle changes to selections via the mouse scroll wheel. See code for more details. 

## Motivation

A smoother UX making selections in plots.    