### PR TITLE
Fix missing renames of db path for selections

### DIFF
--- a/src/inferenceql/viz/panels/table/events.cljs
+++ b/src/inferenceql/viz/panels/table/events.cljs
@@ -20,7 +20,7 @@
                    (assoc-in [:table-panel :headers] (vec headers))
                    (assoc-in [:table-panel :virtual] virtual)
                    ;; Clear all selections in all selection layers.
-                   (assoc-in [:table-panel :selection-layers] {}))]
+                   (assoc-in [:table-panel :selection-layer-coords] {}))]
     {:db new-db
      ;; Clear previous selections made in vega-lite plots.
      :dispatch [:viz/clear-pts-store]}))
@@ -35,7 +35,7 @@
  (fn [{:keys [db]} [_]]
    (let [new-db (-> db
                     (update-in [:table-panel] dissoc :rows :headers)
-                    (assoc-in [:table-panel :selection-layers] {}))]
+                    (assoc-in [:table-panel :selection-layer-coords] {}))]
      {:db new-db
       :dispatch [:viz/clear-pts-store]})))
 


### PR DESCRIPTION
This changes some db paths related to saving selection information. 

These paths should have been changed in a previous PR, #40,  but they were missed. This fixes that.