### PR TITLE
Use virtual flag from query component

### DIFF
--- a/src/inferenceql/viz/components/query/events.cljs
+++ b/src/inferenceql/viz/components/query/events.cljs
@@ -64,7 +64,7 @@
   (try
     (let [result (query/q query rows models)
           columns (:iql/columns (meta result))]
-      {:fx [[:dispatch [:table/set result columns {:virtual false}]]
+      {:fx [[:dispatch [:table/set result columns]]
             [:dispatch [:query/set-details query]]]})
     (catch ExceptionInfo e
       (let [error-messages (if (:cognitect.anomalies/category (ex-data e))
@@ -133,7 +133,7 @@
   [_ [_ query result]]
   (let [{result-rows :result metadata :metadata} result
         {columns :iql/columns} metadata]
-    {:fx [[:dispatch [:table/set result-rows columns {:virtual false}]]
+    {:fx [[:dispatch [:table/set result-rows columns]]
           [:dispatch [:query/set-details query]]]}))
 
 (rf/reg-event-fx :query/post-success event-interceptors post-success)

--- a/src/inferenceql/viz/panels/table/db.cljs
+++ b/src/inferenceql/viz/panels/table/db.cljs
@@ -9,7 +9,6 @@
                                       ::rows
                                       ::visual-headers
                                       ::visual-rows
-                                      ::virtual
                                       ::hot-instance]))
 
 ;;; Specs related to table data.
@@ -20,7 +19,6 @@
 (s/def ::headers (s/coll-of ::header :kind vector?))
 (s/def ::visual-rows (s/coll-of ::row :kind vector?))
 (s/def ::visual-headers (s/coll-of ::header :kind vector?))
-(s/def ::virtual boolean?)
 
 ;;; Specs related to selections within handsontable instances.
 

--- a/src/inferenceql/viz/panels/table/events.cljs
+++ b/src/inferenceql/viz/panels/table/events.cljs
@@ -14,11 +14,10 @@
   Args:
     `rows`: A collection of maps to be set as rows in the table.
     `headers`: The attributes of the maps in `rows` to display in the table."
-  [{:keys [db]} [_ rows headers {:keys [virtual]}]]
+  [{:keys [db]} [_ rows headers]]
   (let [new-db (-> db
                    (assoc-in [:table-panel :rows] (vec rows))
                    (assoc-in [:table-panel :headers] (vec headers))
-                   (assoc-in [:table-panel :virtual] virtual)
                    ;; Clear all selections in all selection layers.
                    (assoc-in [:table-panel :selection-layer-coords] {}))]
     {:db new-db

--- a/src/inferenceql/viz/panels/table/subs.cljs
+++ b/src/inferenceql/viz/panels/table/subs.cljs
@@ -58,12 +58,6 @@
             (fn [[color selection-layer-coords]]
               (get selection-layer-coords color)))
 
-;;; Subs related to the type of data in the table.
-
-(rf/reg-sub :table/virtual
-            (fn [db _]
-              (get-in db [:table-panel :virtual])))
-
 ;;; Subs related to populating tables with data.
 
 (rf/reg-sub :table/table-headers

--- a/src/inferenceql/viz/views.cljs
+++ b/src/inferenceql/viz/views.cljs
@@ -14,7 +14,7 @@
         vega-lite-spec @(rf/subscribe [:viz/vega-lite-spec])
         generators      @(rf/subscribe [:viz/generators])
         pts-store @(rf/subscribe [:viz/pts-store])
-        virtual @(rf/subscribe [:table/virtual])
+        virtual @(rf/subscribe [:query/virtual])
         highlight-class @(rf/subscribe [:table/highlight-class])
         modal-content @(rf/subscribe [:modal/content])]
     [v-box


### PR DESCRIPTION
## What does this do?

The removes the `:virtual` option on the `:table/set` event. The option was always set as false because we previously did not have a means to know whether the data set was virtual or not. 

The table component now gets a new subscription, `:query/virtual` which does know whether the data is virtual, providing the correct value. NOTE: This `:query/virtual` subscription was added in a previous commit. 

## Motivation 

This now allows the table component to color the table rows light-yellow whenever they represent a virtual dataset. 