### PR TITLE
Add query editing defs for adding rowid

### DIFF
--- a/src/inferenceql/viz/components/query/editing.cljc
+++ b/src/inferenceql/viz/components/query/editing.cljc
@@ -1,0 +1,81 @@
+(ns inferenceql.viz.components.query.editing
+  "Defs related to editing inferenceql.query queries."
+  (:require [instaparse.core :as insta]
+            [inferenceql.query :as query]
+            [inferenceql.query.parse-tree :as tree]
+            [clojure.zip :as z]))
+
+(defn make-node
+  "Updates the children in an existing node."
+  [node children]
+  (tree/node (tree/tag node) children))
+
+(defn children
+  "Gets the children of a node.
+  Unlike iql.query.parse-tree/children this does not remove whitespace."
+  [node]
+  (rest node))
+
+(defn zipper
+  "Given an iql.query parse tree, returns a zipper."
+  [node]
+  (z/zipper tree/branch? children make-node node))
+
+(defn seek-tag
+  "Navigates to the first location in a iql.query parse tree with `tag`.
+
+  Args:
+    loc: A zipper of an iql.query parse tree.
+    tag: A tag to search for.
+  Returns:
+    A zipper navigated to a node tagged with `tag`. If such a tagged node can not be found,
+      then returns nil."
+  [loc tag]
+  (cond
+    (z/end? loc)
+    nil
+
+    (and (z/branch? loc) (= tag (tree/tag (z/node loc))))
+    loc
+
+    :else
+    (recur (z/next loc) tag)))
+
+(defn- add-rowid-helper
+  "Performs the heavy lifting for `add-row-id`.
+
+  Args:
+    query: A query string.
+  Returns:
+    A query string."
+  [query]
+  (let [add-rowid (fn [zip]
+                    ;; Takes zip, a zipper that points to a :select-list node.
+                    (let [select-list-str (-> zip
+                                              (z/node)
+                                              (query/unparse))
+                          select-list-node (query/parse (str "rowid, " select-list-str) :start :select-list)]
+                      (z/replace zip select-list-node)))]
+    (-> (query/parse query)
+        (zipper)
+        (seek-tag :select-list)
+        (add-rowid)
+        (z/root)
+        (query/unparse))))
+
+(defn add-rowid
+  "Adds rowid to the start of the select-list in a `query` string.
+  If the query can not be parsed, the original query will be returned.
+  If rowid is already present in the select-list, this is a no-op.
+
+  Args:
+    query: A query string.
+  Returns:
+    A query string."
+  [query]
+  (let [node-or-failure (query/parse query)]
+    (if (insta/failure? node-or-failure)
+      query
+      (if (seek-tag (zipper node-or-failure) :rowid-selection)
+        query
+        (add-rowid-helper query)))))


### PR DESCRIPTION
## What does this do?

This primarily adds a function `add-rowid` that adds `rowid` to the selection-list section of an iql.query query string. 

## Motivation 

Soon iql.viz will use this function to add `rowid` to all executed queries. This is so various few-shot learning UI features can work correctly (such as labeling rows in the UI and having the query-string update automatically with certain row-ids labeled correctly). 

iql.viz will also use these rowids returned as the rowids in Handsontable's leftmost row-headers column. 

## TODO:

* Needs tests
* Needs https://github.com/probcomp/inferenceql.query/issues/90 to be addressed. 