### PR TITLE
Remove outdated elements for scores and labels

### DIFF
--- a/src/inferenceql/viz/panels/table/handsontable.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable.cljs
@@ -1,20 +1,5 @@
 (ns inferenceql.viz.panels.table.handsontable)
 
-(def label-col-header
-  "Header text for the column used for labeling rows as examples."
-  "🏷")
-(def score-col-header
-  "Header text for the column that shows scores."
-  "probability")
-
-(defn freeze-col-1-2-fn [columns-moving target]
-  "Prevents the movement of the first two columns in the table.
-  Also prevents other columns from moving into those frist two spots."
-  (let [first-unfrozen-index 2
-        first-col-moving (first (js->clj columns-moving))]
-    (not (or (< first-col-moving first-unfrozen-index)
-             (< target first-unfrozen-index)))))
-
 (def default-hot-settings
   {:settings {:data                []
               :colHeaders          []
@@ -22,7 +7,6 @@
               :rowHeaders          true
               :multiColumnSorting  true
               :manualColumnMove    true
-              :beforeColumnMove    freeze-col-1-2-fn
               :manualColumnResize  true
               :autoWrapCol         false
               :autoWrapRow         false

--- a/src/inferenceql/viz/panels/table/subs.cljs
+++ b/src/inferenceql/viz/panels/table/subs.cljs
@@ -87,9 +87,7 @@
   in the table including which attribute from the underlying map for the row
   is presented."
   (let [settings-map (fn [attr]
-                       (if (= attr hot/label-col-header)
-                         {:data attr :readOnly false} ; Make the score column user-editable.
-                         {:data attr}))]
+                       {:data attr})]
     (map settings-map headers)))
 
 ;;; Subs related to visual state of the table

--- a/src/inferenceql/viz/panels/viz/vega.cljs
+++ b/src/inferenceql/viz/panels/viz/vega.cljs
@@ -73,9 +73,6 @@
     (cond (probability-column? col-name)
           "quantitative"
 
-          (contains? #{hot/label-col-header} col-name)
-          "nominal"
-
           :else
           ;; Mapping from multi-mix stat-types to vega-lite data-types.
           (let [mapping {:gaussian "quantitative"


### PR DESCRIPTION
This removes some leftover cruft related to the labels column and scores column both of which are no longer in the app. 

Motivation: clean up before the labels column is reintroduced. 