### PR TITLE
Enable label column toggle

### DIFF
--- a/src/inferenceql/viz/panels/table/db.cljs
+++ b/src/inferenceql/viz/panels/table/db.cljs
@@ -2,9 +2,11 @@
   (:require [clojure.spec.alpha :as s]))
 
 (def default-db
-  {:table-panel {:selection-layer-coords {}}})
+  {:table-panel {:selection-layer-coords {}
+                 :show-label-column false}})
 
-(s/def ::table-panel (s/keys :req-un [::selection-layer-coords]
+(s/def ::table-panel (s/keys :req-un [::selection-layer-coords
+                                      ::show-label-column]
                              :opt-un [::headers
                                       ::rows
                                       ::visual-headers
@@ -19,6 +21,7 @@
 (s/def ::headers (s/coll-of ::header :kind vector?))
 (s/def ::visual-rows (s/coll-of ::row :kind vector?))
 (s/def ::visual-headers (s/coll-of ::header :kind vector?))
+(s/def ::show-label-column boolean?)
 
 ;;; Specs related to selections within handsontable instances.
 

--- a/src/inferenceql/viz/panels/table/events.cljs
+++ b/src/inferenceql/viz/panels/table/events.cljs
@@ -15,9 +15,13 @@
     `rows`: A collection of maps to be set as rows in the table.
     `headers`: The attributes of the maps in `rows` to display in the table."
   [{:keys [db]} [_ rows headers]]
-  (let [new-db (-> db
+  (let [headers (->> headers
+                     ;; The first column should always be the :label column, which will get hidden
+                     ;; and shown by the :table/show-label-column event.
+                     (into [:label]))
+        new-db (-> db
                    (assoc-in [:table-panel :rows] (vec rows))
-                   (assoc-in [:table-panel :headers] (vec headers))
+                   (assoc-in [:table-panel :headers] headers)
                    ;; Clear all selections in all selection layers.
                    (assoc-in [:table-panel :selection-layer-coords] {}))]
     {:db new-db
@@ -90,3 +94,8 @@
 (rf/reg-event-db :table/unset-hot-instance
                  event-interceptors
                  unset-hot-instance)
+
+(rf/reg-event-db :table/toggle-label-column
+                 event-interceptors
+                 (fn [db [_]]
+                   (update-in db [:table-panel :show-label-column] not)))

--- a/src/inferenceql/viz/panels/table/handsontable.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable.cljs
@@ -1,5 +1,16 @@
 (ns inferenceql.viz.panels.table.handsontable)
 
+(defn freeze-label-col-pos
+  "Keeps the position of the label column fixed in the table.
+  The label column is meant to always be in the 0-th position.
+  This function is intended to be used as the value of the :beforeColumnMove setting for
+  Handsontable.
+
+  Returns: (bool) Whether to allow the column move or not."
+  [moved-columns _final-index drop-index _move-possible]
+  (and (not-any? #{0} moved-columns) ; The label column is not being moved.
+       (not= drop-index 0))) ; We are not trying to move anything in front of the label column.
+
 (def default-hot-settings
   {:settings {:data                []
               :colHeaders          []
@@ -7,6 +18,7 @@
               :rowHeaders          true
               :multiColumnSorting  true
               :manualColumnMove    true
+              :beforeColumnMove    freeze-label-col-pos
               :manualColumnResize  true
               :autoWrapCol         false
               :autoWrapRow         false

--- a/src/inferenceql/viz/panels/table/subs.cljs
+++ b/src/inferenceql/viz/panels/table/subs.cljs
@@ -121,6 +121,24 @@
             :<- [:table/table-rows]
             show-table-controls)
 
+(rf/reg-sub :table/show-label-column
+            (fn [db _]
+              (get-in db [:table-panel :show-label-column])))
+
+(defn hidden-columns
+  "Returns a value for the Handsontable hiddenColumns setting.
+  Hides the first column when `show-label-column` is false.
+  To be used as a re-frame subscriptions."
+  [show-label-column]
+  (if show-label-column
+    {}
+    {:columns [0]
+     :indicators true}))
+
+(rf/reg-sub :table/hidden-columns
+            :<- [:table/show-label-column]
+            hidden-columns)
+
 ;;; Subs related to various table settings and state.
 
 (defn ^:sub cells
@@ -138,19 +156,21 @@
             cells)
 
 (defn ^:sub real-hot-props
-  [[headers rows context-menu cells selection-coords-active]]
+  [[headers rows context-menu cells hidden-columns selection-coords-active]]
   (-> hot/real-hot-settings
       (assoc-in [:settings :data] rows)
       (assoc-in [:settings :colHeaders] (display-headers headers))
       (assoc-in [:settings :columns] (column-settings headers))
       (assoc-in [:settings :cells] cells)
       (assoc-in [:settings :contextMenu] context-menu)
+      (assoc-in [:settings :hiddenColumns] hidden-columns)
       (assoc-in [:selections-coords] selection-coords-active)))
 (rf/reg-sub :table/real-hot-props
             :<- [:table/table-headers]
             :<- [:table/table-rows]
             :<- [:table/context-menu]
             :<- [:table/cells]
+            :<- [:table/hidden-columns]
             :<- [:table/selection-coords-active]
             real-hot-props)
 


### PR DESCRIPTION
## What does this do?

This makes the `labels` button toggle the labels column to be visible/hidden.

This is done by adding the `:table/toggle-label-column` event and all supporting elements. 

Cells in the label column are not yet editable. This will be changed shortly. 

## Motivation 

Part of the UI changes for enabling few-shot learning. 