### PR TITLE
Make label column editable and update styling

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -228,7 +228,6 @@ div {
 
 .handsontable tr td.label-cell {
   font-weight: 600;
-  font-style: italic;
 }
 
 .handsontable tr td.selected-row {

--- a/src/inferenceql/viz/panels/table/subs.cljs
+++ b/src/inferenceql/viz/panels/table/subs.cljs
@@ -129,11 +129,16 @@
   "Returns a function used by the :cells property in Handsontable's options.
   Provides special styling for rows selected through vega-lite visualizations."
   [selected-row-flags]
-  (fn [row _col _prop]
-    (let [selected (when row (nth selected-row-flags row))]
-      (if selected
-        #js {:className "selected-row"}
-        #js {:className ""}))))
+  (fn [row _col prop]
+    (let [selected (when row (nth selected-row-flags row))
+          label-column-cell (= prop (name :label))
+
+          class-names [(when selected "selected-row")
+                       (when label-column-cell "label-cell")]
+          class-names-string (str/join ", " (remove nil? class-names))]
+      #js {:className class-names-string
+           ;; Make cells in the :label column editable
+           :readOnly (not label-column-cell)})))
 
 (rf/reg-sub :table/cells
             :<- [:table/selected-row-flags]


### PR DESCRIPTION
## What does this do?

This makes cells in the `labels` column editable and adds special styling via css.

Also this makes a small update to a css class for cells in the label column.   

## Motivation 

Part of the UI changes for enabling few-shot learning. 