### PR TITLE
Move :table/check-selection to a stand alone func

### DIFF
--- a/src/inferenceql/viz/panels/table/events.cljs
+++ b/src/inferenceql/viz/panels/table/events.cljs
@@ -2,7 +2,6 @@
   "Re-frame events related to data and selections in Handsontable"
   (:refer-clojure :exclude [set])
   (:require [re-frame.core :as rf]
-            [inferenceql.viz.panels.table.db :as db]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
             [inferenceql.viz.panels.control.db :as control-db]
             [inferenceql.viz.util :as util]))
@@ -37,41 +36,6 @@
                     (assoc-in [:table-panel :selection-layer-coords] {}))]
      {:db new-db
       :dispatch [:viz/clear-pts-store]})))
-
-;; Checks if the selection in the current selection layer is valid.
-;; If it is not valid, the current selection layer is cleared.
-(rf/reg-event-db
- :table/check-selection
- event-interceptors
- (fn [db _]
-   (let [color (control-db/selection-color db)
-         selections-coords (get-in db [:table-panel :selection-layer-coords color])
-
-         num-rows (count (db/visual-rows db))
-         ;; Takes a selection vector and returns true if that selection represents
-         ;; the selection of a single column.
-         column-selected (fn [[row-start col-start row-end col-end]]
-                           (let [last-row-index (- num-rows 1)]
-                             (and (= row-start 0)
-                                  (= row-end last-row-index)
-                                  (= col-start col-end))))]
-     (cond
-       ;; These next two cond sections sometimes deselect all cells in the selection layer in order
-       ;; to enforce our constraints on what sorts of selections are allowed in each selection layer.
-
-       ;; Deselect all cells in the current selection layer if it is made up of two selections that
-       ;; are not both single column selections.
-       (and (= (count selections-coords) 2)
-            (not-every? column-selected selections-coords))
-       (update-in db [:table-panel :selection-layer-coords] dissoc color)
-
-       ;; Deselect all cells in the current selection layer if it is made up of more than
-       ;; two selections.
-       (> (count selections-coords) 2)
-       (update-in db [:table-panel :selection-layer-coords] dissoc color)
-
-       :else
-       db))))
 
 (defn set-hot-instance
   "To be used as re-frame event-db."


### PR DESCRIPTION
## What does this do??

Previously the `:table/check-selection` event would always be dispatched by the `:table/after-selection-end` event.  

`:table/check-selection` would undo the selection if it was invalid. 

Now `:table/after-selection-end` calls a function to check the selection before saving it or not. 

The logic for checking the selection is all the same. 

## Motivation 

Code clean up / simplicity. 