### PR TITLE
Remove data and model namespaces

### DIFF
--- a/src/inferenceql/viz/components/highlight/events.cljs
+++ b/src/inferenceql/viz/components/highlight/events.cljs
@@ -3,15 +3,19 @@
             [inferenceql.viz.db :as db]
             [inferenceql.viz.panels.table.db :as table-db]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
-            [inferenceql.viz.model :as model]
             [inferenceql.viz.score :as score]))
+
+;; TODO: Update this code no longer depend on a static multimix spec definition.
+;; `spec` here is just a dummy placeholder for a multimix spec.
+;; Instead, this code can grab the current model (XCat or other) from the app-db.
+(def spec nil)
 
 (rf/reg-event-db
  :highlight/compute-row-likelihoods
  event-interceptors
  (fn [db [_]]
    (let [table-rows (table-db/table-rows db)
-         likelihoods (score/row-likelihoods model/spec table-rows)]
+         likelihoods (score/row-likelihoods spec table-rows)]
      (assoc-in db [:highlight-component :row-likelihoods] likelihoods))))
 
 (rf/reg-event-db
@@ -20,5 +24,5 @@
  (fn [db [_]]
    (let [table-rows (table-db/table-rows db)
          headers (table-db/table-headers db)
-         missing-cells (score/impute-missing-cells model/spec headers table-rows)]
+         missing-cells (score/impute-missing-cells spec headers table-rows)]
      (assoc-in db [:highlight-component :missing-cells] missing-cells))))

--- a/src/inferenceql/viz/components/query/events.cljs
+++ b/src/inferenceql/viz/components/query/events.cljs
@@ -7,7 +7,6 @@
             [inferenceql.viz.config :as config]
             [inferenceql.viz.panels.table.db :as table-db]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
-            [inferenceql.viz.model :as model]
             [inferenceql.inference.gpm :as gpm]
             [medley.core :as medley]
             [day8.re-frame.http-fx]

--- a/src/inferenceql/viz/data.cljc
+++ b/src/inferenceql/viz/data.cljc
@@ -1,8 +1,0 @@
-(ns inferenceql.viz.data
-  (:require [inferenceql.viz.csv :as csv-utils]
-            [inferenceql.viz.config :as config]))
-
-(def nyt-data
-  (let [column-types (get-in config/config [:model :vars])
-        csv-data (get config/config :data)]
-    (csv-utils/csv-data->clean-maps column-types csv-data {:keywordize-cols true})))

--- a/src/inferenceql/viz/model.cljc
+++ b/src/inferenceql/viz/model.cljc
@@ -1,7 +1,0 @@
-(ns inferenceql.viz.model)
-
-;; TODO: remove this namespace.
-;; Currently code in the score component and inferenceql.search-by-example reference spec.
-;; However the app is no longer centered around multi-mix specs, so this other code should be
-;; changed and this namespace eventually removed.
-(def spec nil)

--- a/src/inferenceql/viz/panels/jsmodel/subs.cljs
+++ b/src/inferenceql/viz/panels/jsmodel/subs.cljs
@@ -1,7 +1,6 @@
 (ns inferenceql.viz.panels.jsmodel.subs
   (:require [cljstache.core :refer [render]]
             [inferenceql.viz.config :refer [config]]
-            [inferenceql.viz.model :as model]
             [inferenceql.viz.panels.jsmodel.multimix :as multimix]
             [inferenceql.inference.gpm.crosscat :as crosscat]
             [re-frame.core :as rf]))

--- a/src/inferenceql/viz/panels/viz/vega.cljs
+++ b/src/inferenceql/viz/panels/viz/vega.cljs
@@ -2,7 +2,6 @@
   "Code related to generating vega-lite specs"
   (:require [clojure.walk :as walk]
             [clojure.string :as string]
-            [inferenceql.viz.model :as model]
             [inferenceql.viz.panels.table.handsontable :as hot]
             [inferenceql.viz.panels.table.db :as table-db]
             [inferenceql.viz.config :as config]


### PR DESCRIPTION
## What does this do?

This removes `model.cljc` and `data.cljc` which were used to store definitions for the the model and dataset previously. This work has been moved to the store component located at `src/inferenceql/viz/components/store/db.cljs`.

* There were a few namespaces requiring `inferenceql.viz.model`, but not using it. These lines were removed. 

* A file in the store component was using `inferenceql.viz.model`, but that use has now been stubbed out. The store component is not functional or used at the moment anyways, so this change should have no impact. 

## Motivation 

Code clean up.