### PR TITLE
Use gpm edn readers from iql.inference

### DIFF
--- a/src/inferenceql/viz/config_reader.clj
+++ b/src/inferenceql/viz/config_reader.clj
@@ -5,7 +5,7 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [aero.core :as aero]
-            [inferenceql.viz.util :as util]))
+            [inferenceql.inference.gpm :as gpm]))
 
 (defmethod aero/reader 'txt
   [_ _ s]
@@ -17,7 +17,7 @@
 
 (defmethod aero/reader 'edn
   [_ _ s]
-  (->> s (io/resource) (slurp) (edn/read-string {:readers util/edn-readers})))
+  (->> s (io/resource) (slurp) (edn/read-string {:readers gpm/readers})))
 
 (defmethod aero/reader 'json
   [_ _ s]

--- a/src/inferenceql/viz/panels/upload/events.cljs
+++ b/src/inferenceql/viz/panels/upload/events.cljs
@@ -3,11 +3,11 @@
   (:require [clojure.edn :as edn]
             [re-frame.core :as rf]
             [goog.labs.format.csv :as csv]
+            [medley.core :refer [index-by map-vals find-first]]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
             [inferenceql.viz.csv :as csv-utils]
             [inferenceql.auto-modeling.bayesdb-import :as bayesdb-import]
-            [medley.core :refer [index-by map-vals find-first]]
-            [inferenceql.viz.util :as util]))
+            [inferenceql.inference.gpm :as gpm]))
 
 (defn ^:event-fx read-form
   "Starts the processing of a form for uploading a new dataset and model.
@@ -133,7 +133,7 @@
                                    (js->clj (.parse js/JSON (:raw-data model-read)))
                                    dataset-rows)))
                                :edn
-                               (edn/read-string {:readers util/edn-readers}
+                               (edn/read-string {:readers gpm/readers}
                                                 (:raw-data model-read))))
                            model-reads)
 

--- a/src/inferenceql/viz/util.cljc
+++ b/src/inferenceql/viz/util.cljc
@@ -1,12 +1,6 @@
 (ns inferenceql.viz.util
   (:require [medley.core :as medley]
-            [lambdaisland.uri :refer [query-map]]
-            [inferenceql.inference.gpm]
-            [inferenceql.inference.gpm.crosscat :as xcat]
-            [inferenceql.inference.gpm.view :as view]
-            [inferenceql.inference.gpm.column :as column]
-            [inferenceql.inference.gpm.primitive-gpms.categorical :as categorical]
-            [inferenceql.inference.gpm.primitive-gpms.gaussian :as gaussian]))
+            [lambdaisland.uri :refer [query-map]]))
 
 (defn filter-nil-kvs [a-map]
   (into {} (remove (comp nil? val) a-map)))
@@ -30,21 +24,3 @@
   (let [app-url #?(:cljs (.-location js/window)
                    :clj nil)]
     (query-map app-url {:multikeys :never})))
-
-(def edn-readers
-  "A map of tag symbols to data-reader functions for use with `clojure.edn/read`
-  and `clojure.edn/read-string`."
-  {'inferenceql.inference.gpm.primitive_gpms.gaussian.Gaussian
-   gaussian/map->Gaussian
-
-   'inferenceql.inference.gpm.column.Column
-   column/map->Column
-
-   'inferenceql.inference.gpm.view.View
-   view/map->View
-
-   'inferenceql.inference.gpm.primitive_gpms.categorical.Categorical
-   categorical/map->Categorical
-
-   'inferenceql.inference.gpm.crosscat.XCat
-   xcat/map->XCat})


### PR DESCRIPTION
Motivation: avoiding duplication and also adding missing readers (bernoulli) by using those already defined in iql.inference.