### PR TITLE
Add few-shot learning UI changes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,9 +19,9 @@
         cljstache/cljstache {:mvn/version "2.0.6"}
         cljsjs/highlight {:mvn/version "9.12.0-2"}
         probcomp/inferenceql.inference {:git/url "git@github.com:probcomp/inferenceql.inference.git"
-                                        :sha "9b906a91b47245c2d99c3450971cf4acd6b0c7c9"}
+                                        :sha "38e1086fb2c98191bc6eb5285665c67fb16ebb5c"}
         probcomp/inferenceql.query {:git/url "git@github.com:probcomp/inferenceql.query.git"
-                                    :sha "3cef811a3f6e4500514e8aa8cb5362dc0e757384"}
+                                    :sha "f4e0d8033130864db33671c634e42aa1f1f17d5c"}
         probcomp/inferenceql.auto-modeling {:git/url "git@github.com:probcomp/inferenceql.auto-modeling.git"
                                             :sha "506e847f55b0379b3888e0f2b2d3fa0e52f2166e"}
         probcomp/metaprob {:git/url "https://github.com/probcomp/metaprob.git"

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -66,9 +66,9 @@ div {
 
 #search-input {
   width: 100%;
-  height: 60px;
+  height: 150px;
   min-height: 60px;
-  max-height: 200px;
+  max-height: 250px;
   resize: vertical;
   font-size: .875rem;
   font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
@@ -228,6 +228,7 @@ div {
 
 .handsontable tr td.label-cell {
   font-weight: 600;
+  font-style: normal;
 }
 
 .handsontable tr td.selected-row {

--- a/src/inferenceql/viz/components/highlight/events.cljs
+++ b/src/inferenceql/viz/components/highlight/events.cljs
@@ -1,6 +1,5 @@
 (ns inferenceql.viz.components.highlight.events
   (:require [re-frame.core :as rf]
-            [inferenceql.viz.db :as db]
             [inferenceql.viz.panels.table.db :as table-db]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
             [inferenceql.viz.score :as score]))
@@ -14,7 +13,7 @@
  :highlight/compute-row-likelihoods
  event-interceptors
  (fn [db [_]]
-   (let [table-rows (table-db/table-rows db)
+   (let [table-rows (table-db/physical-rows db)
          likelihoods (score/row-likelihoods spec table-rows)]
      (assoc-in db [:highlight-component :row-likelihoods] likelihoods))))
 
@@ -22,7 +21,7 @@
  :highlight/compute-missing-cells
  event-interceptors
  (fn [db [_]]
-   (let [table-rows (table-db/table-rows db)
-         headers (table-db/table-headers db)
+   (let [table-rows (table-db/physical-rows db)
+         headers (table-db/physical-headers db)
          missing-cells (score/impute-missing-cells spec headers table-rows)]
      (assoc-in db [:highlight-component :missing-cells] missing-cells))))

--- a/src/inferenceql/viz/components/query/db.cljs
+++ b/src/inferenceql/viz/components/query/db.cljs
@@ -13,7 +13,10 @@
 (s/def ::query-component (s/keys :req-un [::dataset-name
                                           ::model-name]
                                  :opt-un [::virtual
-                                          ::column-details]))
+                                          ::column-details
+                                          ::query
+                                          ::schema
+                                          ::schema-base]))
 
 ;; The dataset referenced in the last query executed.
 (s/def ::dataset-name keyword?)
@@ -43,3 +46,26 @@
 
 (s/def ::column-details (s/coll-of ::column-detail))
 (s/def ::column-detail (s/multi-spec column-detail-type ::detail-type))
+
+;; The executed query whose results are currently displayed.
+(s/def ::query string?)
+
+;; The schema for the data produced by the executed query.
+(s/def ::schema ::store/schema)
+
+;; The schema for the original dataset referenced in the executed query.
+(s/def ::schema-base ::store/schema)
+
+;;; Accessor functions to portions of the table-panel db.
+
+(defn query
+  [db]
+  (get-in db [:query-component :query]))
+
+(defn schema-base
+  [db]
+  (get-in db [:query-component :schema-base]))
+
+(defn schema
+  [db]
+  (get-in db [:query-component :schema]))

--- a/src/inferenceql/viz/components/query/editing.cljc
+++ b/src/inferenceql/viz/components/query/editing.cljc
@@ -1,0 +1,367 @@
+(ns inferenceql.viz.components.query.editing
+  "Defs related to editing inferenceql.query queries."
+  (:require [instaparse.core :as insta]
+            [inferenceql.query :as query]
+            [inferenceql.query.parse-tree :as tree]
+            [inferenceql.viz.util :refer [coerce-bool]]
+            [inferenceql.viz.components.query.util :refer [long-str make-node children zipper
+                                                           seek-tag]]
+            [clojure.zip :as z]
+            [clojure.string :as str]
+            [medley.core :as medley]
+            #?(:cljs [goog.string :refer [format]])))
+
+;;; Functions for adding special columns (needed by iql.viz) to an iql.query query.
+
+(defn- add-rowid-and-label-helper
+  "Performs the heavy lifting for `add-row-id`.
+
+  Args:
+    query: A query string.
+  Returns:
+    A query string."
+  [query]
+  (let [rowid-selection-node (query/parse "rowid" :start :selection)
+        editable-col-selection-node (query/parse "editable" :start :selection)
+        label-col-selection-node (query/parse "label" :start :selection)
+
+        add-rowid (fn [select-list-node]
+                    (let [selections (into [rowid-selection-node
+                                            editable-col-selection-node
+                                            label-col-selection-node]
+                                           (tree/child-nodes select-list-node))
+                          selections (as-> selections $
+                                           (interleave $ (repeat ",") (repeat (query/parse " " :start :ws)))
+                                           (drop-last 2 $))]
+
+                      (tree/node :select-list selections)))]
+    (-> (query/parse query)
+        (zipper)
+        (seek-tag :select-list)
+        (z/edit add-rowid)
+        (z/root)
+        (query/unparse))))
+
+(defn add-rowid-and-label
+  "Adds rowid to the start of the select-list in a `query` string.
+  If the query can not be parsed, the original query will be returned.
+  If rowid is already present in the select-list, this is a no-op.
+
+  Args:
+    query: A query string.
+  Returns:
+    A query string."
+  [query]
+  (let [node-or-failure (query/parse query)]
+    (if (insta/failure? node-or-failure)
+      query
+      (add-rowid-and-label-helper query))))
+
+;;; Functions related to adding ALTER and UPDATE and INSERT expressions
+;;; for label column and new rows.
+
+(def whitespace (query/parse "\n     " :start :ws))
+
+(defn with-sub-query-node [qs]
+  (let [qz (-> qs query/parse zipper)
+        qz-with (seek-tag qz :with-expr)]
+    (if qz-with
+      (-> (z/node qz-with)
+          (tree/get-node-in [:with-sub-expr :query-expr]))
+      (z/node qz))))
+
+;----------------
+
+(def label-alter-node (query/parse "(ALTER data ADD label) AS data" :start :with-map-entry-expr))
+
+(defn is-label-alter? [node]
+  (let [val-expr (tree/get-node node :with-map-value-expr)
+        alter-expr (some-> (zipper val-expr)
+                           (seek-tag :alter-expr)
+                           (z/node))
+        table-name (some-> alter-expr
+                           (tree/get-node-in [:table-expr :ref])
+                           (query/unparse))
+        column-name (some-> alter-expr
+                            (tree/get-node-in [:column-expr])
+                            (query/unparse))
+
+        binding-name (-> (tree/get-node node :name)
+                         (query/unparse))]
+    (and (= table-name "data")
+         (= column-name "label")
+         (= binding-name "data"))))
+
+(defn remove-label-alter [entry-exprs]
+  (remove is-label-alter? entry-exprs))
+
+(defn add-label-alter [entry-exprs]
+  (concat entry-exprs [label-alter-node]))
+
+;----------------
+
+(defn reduce-or-node [node]
+  (let [reducer (fn reducer [node]
+                  (case (tree/tag node)
+                    :or-condition (let [child-nodes (tree/child-nodes node)]
+                                    (case (count child-nodes)
+                                      1 (reducer (tree/only-child node))
+                                      2 (let [where-pairs (map reducer child-nodes)]
+                                          (if (every? some? where-pairs)
+                                            (apply concat where-pairs)
+                                            nil))))
+                    :condition (reducer (tree/only-child node))
+                    :equality-condition (let [selection (some-> node
+                                                                (tree/get-node :selection)
+                                                                (query/eval {}))
+                                              value (some-> node
+                                                            (tree/get-node :value)
+                                                            (query/eval {}))]
+                                          [[selection value]])
+                    nil))]
+    (reducer node)))
+
+(defn update-node-map [node]
+  (let [val-expr (tree/get-node node :with-map-value-expr)
+        update-expr (some-> (zipper val-expr)
+                            (seek-tag :update-expr)
+                            (z/node))
+        table-name (some-> update-expr
+                           (tree/get-node-in [:table-expr :ref])
+                           (query/unparse))
+
+        eval #(query/eval % {})
+        set-map-exprs (some-> update-expr
+                              (tree/get-node-in [:set-clause :map-expr])
+                              (tree/child-nodes))
+        set-map (apply merge (map eval set-map-exprs))
+
+        where-pairs  (some-> update-expr
+                             (tree/get-node-in [:where-clause :or-condition])
+                             (reduce-or-node))
+        binding-name (-> (tree/get-node node :name)
+                         (query/unparse))
+
+        is-label-update (and (= table-name "data")
+                             (every? #(and (= "rowid" (first %)) (integer? (second %)))
+                                     where-pairs)
+                             (or (= set-map {:label true})
+                                 (= set-map {:label false}))
+                             (= binding-name "data"))]
+    (when is-label-update
+      (zipmap (map second where-pairs)
+              (repeat (:label set-map))))))
+
+(defn make-update-label-node [updates label-val]
+  (let [rowids (-> (medley/filter-vals {label-val true} updates)
+                   (keys))]
+    (when (seq rowids)
+      (let [cond-str (->> rowids
+                          (map #(format "rowid=%d" %))
+                          (str/join " OR "))
+            qs (format "(UPDATE data SET label=%s WHERE %s) AS data" label-val cond-str)]
+        (query/parse qs :start :with-map-entry-expr)))))
+
+(defn remove-label-update [entry-exprs]
+  (remove update-node-map entry-exprs))
+
+(defn add-label-update [entry-exprs updates]
+  (let [pos-update-node (make-update-label-node updates true)
+        neg-update-node (make-update-label-node updates false)]
+    (cond-> entry-exprs
+            pos-update-node (concat [pos-update-node])
+            neg-update-node (concat [neg-update-node]))))
+
+(defn new-row-node? [node]
+  (some-> (zipper node)
+          (seek-tag :insert-into-clause)
+          (some?)))
+
+(defn make-new-row-node [row]
+  (let [kv-strs (for [[k v] row]
+                  (format "%s=%s" k v))
+        row-str (str/join ", " kv-strs)
+        qs (format "(INSERT INTO data VALUES (%s)) AS data" row-str)]
+    (query/parse qs :start :with-map-entry-expr)))
+
+(defn remove-new-rows [entry-exprs]
+  (remove new-row-node? entry-exprs))
+
+(defn add-new-rows [entry-exprs new-rows]
+  (concat entry-exprs (map make-new-row-node new-rows)))
+
+;----------------
+
+(defn edit-map-exprs [node f & args]
+  (let [f-ready #(apply f (concat [%] args))
+        entry-exprs (-> node
+                        (tree/get-node :with-map-expr)
+                        (tree/child-nodes)
+                        (f-ready))
+
+        ;; Add commas and whitespace
+        entry-exprs (as-> entry-exprs $
+                          (interleave $ (repeat ",") (repeat whitespace))
+                          (drop-last 2 $))]
+    (-> (zipper node)
+        (seek-tag :with-map-expr)
+        (z/replace (tree/node :with-map-expr entry-exprs))
+        (z/root))))
+
+(defn add-new-with [sub-query-node label-vals new-rows]
+  (if (or (seq label-vals) (seq new-rows))
+    (let [pos-update-node (make-update-label-node label-vals true)
+          neg-update-node (make-update-label-node label-vals false)
+          new-row-nodes (map make-new-row-node new-rows)
+
+          entry-exprs (cond-> []
+                              (seq label-vals) (concat [label-alter-node])
+                              pos-update-node (concat [pos-update-node])
+                              neg-update-node (concat [neg-update-node])
+                              (seq new-row-nodes) (concat new-row-nodes))
+          entry-exprs (as-> entry-exprs $
+                            (interleave $ (repeat ",") (repeat whitespace))
+                            (drop-last 2 $))
+          with-map-expr (tree/node :with-map-expr entry-exprs)]
+      (str "WITH " (query/unparse with-map-expr) ":\n" (query/unparse sub-query-node)))
+    (query/unparse sub-query-node)))
+
+(defn handle [qz-with sub-query-node label-vals new-rows]
+  (if qz-with
+    (let [with-node (z/node qz-with)
+          new-with-node (cond-> with-node
+                                :always (edit-map-exprs remove-label-alter)
+                                :always (edit-map-exprs remove-label-update)
+                                :always (edit-map-exprs remove-new-rows)
+                                (seq label-vals) (edit-map-exprs add-label-alter)
+                                (seq label-vals) (edit-map-exprs add-label-update label-vals)
+                                (seq new-rows) (edit-map-exprs add-new-rows new-rows))
+
+          has-map-entries (-> new-with-node
+                              (tree/get-node :with-map-expr)
+                              (tree/child-nodes)
+                              (seq))
+
+          return-node (if has-map-entries
+                        (-> qz-with
+                            (z/replace new-with-node)
+                            (seek-tag :query-expr)
+                            (z/replace sub-query-node)
+                            (z/root))
+                        sub-query-node)]
+      (query/unparse return-node))
+    (add-new-with sub-query-node label-vals new-rows)))
+
+(defn add-edit-exprs
+  "Returns an query string such that changes to the dataset in the UI are reflected in the query.
+
+  Changes are added to the query by surrounding it with a WITH expression (with-expr) with
+  potentially many bindings (with-map-entry-expr) which simply rebind the data dataset each time
+  with additional changes.
+
+  If the query already has a WITH expression that same WITH expression will be used to add bindings
+  for the changes. If some bindings for dataset changes are already present in the WITH expression,
+  they will be removed, and the current changes passed in will be added.
+
+  For adding changes in UI label column (label-vals), this function will add expressions of ALTER
+  data and UPDATE data into the WITH. For user-added rows (new-rows), it will add INSERT INTO
+  expressions into the WITH.
+
+  Args:
+   cur-qs - The current query string in the control-panel textarea input.
+   prev-qs - The previously executed query string.
+   label-vals - A map of row-id to boolean representing the column of user-added labels in the UI.
+   new-rows - A sequence of user-added rows. The rows should only include keys that have
+     been modeled and can include the key :label for labels on user-added rows.
+
+     They should also include a key :editable with value true. This allows the rows to be considered
+     as user-added rows after the query is executed.
+
+  Returns a query string or nil if the original query string could not be parsed."
+  [cur-qs prev-qs label-vals new-rows]
+  (let [cur-qs (str/trim cur-qs)]
+    (when-not (insta/failure? (query/parse cur-qs))
+      ;; Edit the query.
+      (let [prev-qz (some-> prev-qs query/parse zipper)
+            prev-qz-with (some-> prev-qz (seek-tag :with-expr))
+            cur-qz (some-> cur-qs query/parse zipper)
+            cur-qz-with (some-> cur-qz (seek-tag :with-expr))
+            sub-query-node (with-sub-query-node cur-qs)]
+        (if prev-qz-with
+          ;; Use the previous WITH clause.
+          (handle prev-qz-with sub-query-node label-vals new-rows)
+          ;; Use the current WITH clause.
+          (handle cur-qz-with sub-query-node label-vals new-rows))))))
+
+;;; Functions related to adding INCORPORATE expressions for label column and new rows.
+
+(defn maybe-incorp-node [label-vals editable-rows model-name]
+  (let [column-incorp (if (seq label-vals)
+                        ;; Create an INCORPORATE statement.
+                        (let [bindings-str (->> (seq label-vals)
+                                                (sort-by first)
+                                                (map (fn [[k v]] (format "%s=%s" k v)))
+                                                (str/join ", "))]
+                          (format "(INCORPORATE COLUMN (%s) AS label INTO %s)", bindings-str model-name))
+                        model-name)
+        row-incorps  (if (seq editable-rows)
+                       (loop [[r & rs] (reverse editable-rows) query column-incorp]
+                         (if r
+                           (let [kv-strs (for [[k v] r]
+                                           (format "%s=%s" k v))
+                                 row-str (str/join ", " kv-strs)
+                                 new-query (format "(INCORPORATE ROW (%s) INTO %s)" row-str query)]
+                             (recur rs new-query))
+                           query))
+                       column-incorp)]
+    (query/parse row-incorps :start :model-expr)))
+
+(defn add-incorp-node [node label-vals editable-rows]
+  (let [loc (zipper node)
+        incorp-loc (seek-tag loc :incorporate-expr)
+        model-name (if incorp-loc
+                       (-> incorp-loc
+                           (seek-tag :ref)
+                           (z/node)
+                           (tree/get-node-in [:name :simple-symbol])
+                           (tree/only-child))
+                       (-> (seek-tag loc :simple-symbol)
+                           (z/node)
+                           (tree/only-child)))
+        new-model-expr-node (maybe-incorp-node label-vals editable-rows model-name)]
+    ;; NOTE: or I could edit the original node
+    [:under-clause "UNDER" [:ws " "] new-model-expr-node]))
+
+(defn add-incorp-expr
+  "Returns an query string with any reference to a model wrapped in potentially many INCORPORATE
+  exprs.
+
+  This is used to add an expression of INCORPORATE column for a column of user-added labels
+  (label-vals) and potentially many experssions of INCORPORATE row for user-added rows
+  (editable-rows).
+
+  If model references are already wrapped in INCORPORATE expressions this will remove all of them
+  and add new INCORPORATE expressions based on the data passed in.
+
+  The model reference is first wrapped in an INCORPORATE column expression and then its is wrapped
+  in one or many INCORPORATE row expressions. This is so the :label column is added to the model
+  first, and user-added rows with :label keys are actually have their label values INCORPORATED as
+  well.
+
+  Args:
+    query-string - A query string.
+    label-vals - A map of row-id to boolean representing the column of user-added labels in the UI.
+    editable-rows - A sequence of user-added rows. The rows should only include keys that have
+      been modeled and can include the key :label for labels on user-added rows.
+
+  Returns a query string or nil if the original query string could not be parsed."
+  [query-string label-vals editable-rows]
+  (let [query-string (str/trim query-string)]
+    (when-not (insta/failure? (query/parse query-string))
+      ;; Edit the query.
+      (loop [qz (-> query-string query/parse zipper)]
+        (if (z/end? qz)
+          (-> qz z/node query/unparse)
+          (if-let [qz-under (seek-tag qz :under-clause)]
+            (recur (z/next (z/edit qz-under add-incorp-node label-vals editable-rows)))
+            (recur (z/next qz))))))))

--- a/src/inferenceql/viz/components/query/util.cljc
+++ b/src/inferenceql/viz/components/query/util.cljc
@@ -2,17 +2,61 @@
   "Utility functions for manipulating and extracting info from iql.query parse trees."
   (:require [instaparse.core :as insta]
             [inferenceql.query :as query]
-            [inferenceql.query.parse-tree :as tree]))
+            [inferenceql.query.parse-tree :as tree]
+            [clojure.zip :as z]))
 
-;;; Functions related to (column-details)
+;;; Various utility functions related to queries.
+
+(defn long-str [& strings] (clojure.string/join "\n" strings))
+
+(defn make-node
+  "Updates the children in an existing node."
+  [node children]
+  (tree/node (tree/tag node) children))
+
+(defn children
+  "Gets the children of a node.
+  Unlike iql.query.parse-tree/children this does not remove whitespace."
+  [node]
+  (rest node))
+
+(defn zipper
+  "Given an iql.query parse tree, returns a zipper."
+  [node]
+  (z/zipper tree/branch? children make-node node))
+
+(defn seek-tag
+  "Navigates to the first location in a iql.query parse tree with `tag`.
+
+  Args:
+    loc: A zipper of an iql.query parse tree.
+    tag: A tag to search for.
+  Returns:
+    A zipper navigated to a node tagged with `tag`. If such a tagged node can not be found,
+      then returns nil."
+  [loc tag]
+  (cond
+    (z/end? loc)
+    nil
+
+    (and (z/branch? loc) (= tag (tree/tag (z/node loc))))
+    loc
+
+    :else
+    (recur (z/next loc) tag)))
+
+;;; Functions related to extracting details about columns from a query.
+;;; e.g. column-renames, new columns (form PROB OF), etc.
 
 (defn- get-selection-list
   "Gets the selection-list portion of the parse `tree`."
   [tree]
   (when-not (insta/failure? tree)
-    (as-> tree $
-      (tree/get-node-in $ [:select-clause :select-list])
-      (tree/child-nodes $))))
+    (-> tree
+        (zipper)
+        (seek-tag :select-list)
+        (z/node)
+        (tree/child-nodes))))
 
 (defn- column-selection-rename
   "Returns a column-detail map for this type of selection node that renames a column."
@@ -54,22 +98,35 @@
   [query]
   (keep column-details-for-selection (get-selection-list (query/parse query))))
 
-;;; Functions related to (virtual-data?)
+(defn column-renames
+  "Returns a map of columns that have been renamed as a result of executing the last query.
 
-(defn- virtual-data-table-expr?
-  "Returns whether this `table-expr` portion of the parse tree generates virtual data."
-  [table-expr]
-  (let [table-expr-contents (first (tree/child-nodes table-expr))
-        table-expr-type (tree/tag table-expr-contents)]
-    (case table-expr-type
-      :table-expr (virtual-data-table-expr? table-expr-contents)
-      :generated-table-expr true
-      false)))
+  Columns can be renames in queries using the AS keyword.
+  Returns: {:old-column-name :new-column-name, ...}"
+  [column-details]
+  (->> column-details
+    (filter #(= (:detail-type %) :rename))
+    (map (juxt :old-name :new-name))
+    (into {})))
+
+(defn new-columns-schema
+  "Returns a schema for new columns that were created as a result of executing the last query.
+
+  Returns: {:new-column-name :gaussian, ...}"
+  [column-details]
+  (->> column-details
+    (filter #(= (:detail-type %) :new-column-schema))
+    (map (juxt :name :stat-type))
+    (into {})))
+
+;;; Functions for checking whether a query returned virtual-data.
 
 (defn virtual-data?
   "Returns whether the resultset of `query` represents virtual data."
   [query]
   (let [node-or-failure (query/parse query)]
     (when-not (insta/failure? node-or-failure)
-      (let [table-expr (tree/get-node-in node-or-failure [:from-clause :table-expr])]
-        (virtual-data-table-expr? table-expr)))))
+      (some? (some-> node-or-failure
+                     zipper
+                     (seek-tag :generated-table-expr)
+                     (z/node))))))

--- a/src/inferenceql/viz/components/store/db.cljs
+++ b/src/inferenceql/viz/components/store/db.cljs
@@ -102,3 +102,9 @@
 ;; data. See here for more info:
 ;; https://vega.github.io/vega-lite/docs/projection.html#projection-types
 (s/def ::projection-type #{"albers" "albersUsa" "mercator" "identity"})
+
+;;; Accessor functions to portions of the table-panel db.
+
+(defn datasets
+  [db]
+  (get-in db [:store-component :datasets]))

--- a/src/inferenceql/viz/core.cljs
+++ b/src/inferenceql/viz/core.cljs
@@ -18,6 +18,7 @@
             [inferenceql.viz.panels.table.events]
             [inferenceql.viz.panels.table.subs]
             [inferenceql.viz.panels.table.handsontable-events]
+            [inferenceql.viz.panels.table.handsontable-effects]
             ;; More Panel
             [inferenceql.viz.panels.more.events]
             [inferenceql.viz.panels.more.subs]
@@ -65,4 +66,5 @@
   ;; not reset the state of the app.
   (rf/dispatch-sync [:initialize-db])
   (rf/dispatch-sync [:upload/read-query-string-params (query-string-params)])
+  (rf/dispatch-sync [:control/set-query-string-to-select-all])
   (render-app))

--- a/src/inferenceql/viz/panels/control/db.cljs
+++ b/src/inferenceql/viz/panels/control/db.cljs
@@ -4,7 +4,7 @@
 (def default-db
   {:control-panel {:confidence-threshold 0.9
                    :reagent-forms {:confidence-mode :none}
-                   :query-string "SELECT * FROM data;"
+                   :query-string ""
                    :selection-color :blue}})
 
 

--- a/src/inferenceql/viz/panels/control/views.cljs
+++ b/src/inferenceql/viz/panels/control/views.cljs
@@ -45,16 +45,16 @@
         models (rf/subscribe [:store/models])]
     [:div#toolbar
      [:div#search-section
-       [:textarea#search-input {:on-change #(rf/dispatch [:control/set-query-string (-> % .-target .-value)])
+       [:textarea#search-input {:on-change #(rf/dispatch-sync [:control/set-query-string (-> % .-target .-value)])
                                 ;; This submits the query when enter is pressed, but allows the user
                                 ;; to enter a linebreak in the textarea with shift-enter.
-                                :on-key-press (fn [e] (if (and (= (.-key e) "Enter") (not (.-shiftKey e)))
+                                :on-key-press (fn [e] (if (and (= (.-key e) "Enter") (.-shiftKey e))
                                                         (do
                                                           (.preventDefault e)
                                                           (rf/dispatch [:query/parse-query @input-text @datasets @models]))))
                                 :placeholder (str "Write a query here.\n"
-                                                  "  [shift-enter] - inserts a newline\n"
-                                                  "  [enter] - executes query")
+                                                  "[enter] - inserts a newline\n"
+                                                  "[shift-enter] - executes query")
                                 ;; This random attribute value for autoComplete is needed to turn
                                 ;; autoComplete off in Chrome. "off" and "false" do not work.
                                 :autoComplete "my-search-field"

--- a/src/inferenceql/viz/panels/table/db.cljs
+++ b/src/inferenceql/viz/panels/table/db.cljs
@@ -1,5 +1,8 @@
 (ns inferenceql.viz.panels.table.db
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [medley.core :as medley]
+            [goog.string :refer [format]]
+            [inferenceql.viz.util :refer [coerce-bool]]))
 
 (def default-db
   {:table-panel {:selection-layer-coords {}
@@ -7,20 +10,27 @@
 
 (s/def ::table-panel (s/keys :req-un [::selection-layer-coords
                                       ::show-label-column]
-                             :opt-un [::headers
-                                      ::rows
-                                      ::visual-headers
-                                      ::visual-rows
+                             :opt-un [::physical-data
+                                      ::visual-state
+                                      ::row-ids
+                                      ::rows-by-id
                                       ::hot-instance]))
 
 ;;; Specs related to table data.
 
 (s/def ::header keyword?)
 (s/def ::row (s/map-of ::header any?))
-(s/def ::rows (s/coll-of ::row :kind vector?))
+(s/def ::rowid integer?)
+(s/def ::row-with-id (s/merge ::row (s/keys :req-un [::rowid])))
+
+(s/def ::rows (s/coll-of ::row-with-id :kind vector?))
 (s/def ::headers (s/coll-of ::header :kind vector?))
-(s/def ::visual-rows (s/coll-of ::row :kind vector?))
-(s/def ::visual-headers (s/coll-of ::header :kind vector?))
+
+(s/def ::row-ids (s/coll-of ::rowid :kind vector?))
+(s/def ::rows-by-id (s/map-of ::rowid ::row-with-id))
+(s/def ::physical-data (s/keys :opt-un [::headers ::row-ids ::rows-by-id]))
+
+(s/def ::visual-state (s/keys :opt-un [::headers ::row-ids]))
 (s/def ::show-label-column boolean?)
 
 ;;; Specs related to selections within handsontable instances.
@@ -43,19 +53,71 @@
 
 ;;; Accessor functions to portions of the table-panel db.
 
-(defn table-headers
+(defn physical-headers
   [db]
-  (get-in db [:table-panel :headers]))
+  (get-in db [:table-panel :physical-data  :headers]))
 
-(defn table-rows
+(defn physical-rows
   [db]
-  (get-in db [:table-panel :rows] []))
+  (let [row-ids (get-in db [:table-panel :physical-data :row-ids])
+        rows-by-id (get-in db [:table-panel :physical-data :rows-by-id])]
+    (map rows-by-id row-ids)))
 
-(defn visual-headers
+(defn visual-row-ids
   [db]
-  (get-in db [:table-panel :visual-headers]))
+  (get-in db [:table-panel :visual-state :row-ids]))
 
-(defn visual-rows
+(defn selection-layer-coords
   [db]
-  (get-in db [:table-panel :visual-rows]))
+  (get-in db [:table-panel :selection-layer-coords]))
 
+(defn hot-instance
+  [db]
+  (get-in db [:table-panel :hot-instance]))
+
+;;; Functions for extracting specialized info from :rows-by-id.
+
+(defn editable-rows
+  "Returns a sequence of user-edited rows to be used with auto query-editing.
+
+  Args:
+    db - Re-frame app-db.
+    schema - The schema for the original dataset (not including new columns and column renames)."
+  [db schema]
+  (let [rows-by-id (get-in db [:table-panel :rows-by-id])
+        row-ids (get-in db [:table-panel :row-ids])
+        rows (filter :editable (mapv rows-by-id row-ids))
+        quote-strings #(if (string? %) (format "\"%s\"" %) %)
+        ;; Not keeping :rowid key.
+        ;; Keeping columns in the original datasets plus :editable and :label
+        keys-to-keep (conj (keys schema) :editable :label)]
+    (vec (for [r rows]
+           (as-> r $
+             (select-keys $ keys-to-keep)
+             (medley/update-existing $ :label coerce-bool)
+             (medley/remove-vals nil? $)
+             (medley/remove-vals #(= "" %) $)
+             (medley/map-keys name $)
+             (medley/map-vals quote-strings $))))))
+
+(defn editable-rows-for-incorp
+  "Returns sequence of user-edited rows to be used in incorporate clauses for auto query-editing.
+
+  Args:
+    db - Re-frame app-db.
+    schema - The schema for the original dataset (not including new columns and column renames)."
+  [db schema]
+  (->> (for [r (editable-rows db schema)]
+         (dissoc r "editable"))
+       ;; Remove empty rows;
+       (filter seq)
+       (vec)))
+
+(defn label-values
+  "Returns a map of row-id to boolean label value for all original rows (not user-edited). "
+  [db]
+  (->> (get-in db [:table-panel :rows-by-id])
+       (medley/remove-vals :editable)
+       (medley/map-vals :label)
+       (medley/map-vals coerce-bool)
+       (medley/filter-vals some?)))

--- a/src/inferenceql/viz/panels/table/events.cljs
+++ b/src/inferenceql/viz/panels/table/events.cljs
@@ -2,9 +2,9 @@
   "Re-frame events related to data and selections in Handsontable"
   (:refer-clojure :exclude [set])
   (:require [re-frame.core :as rf]
-            [inferenceql.viz.events.interceptors :refer [event-interceptors]]
-            [inferenceql.viz.panels.control.db :as control-db]
-            [inferenceql.viz.util :as util]))
+            [medley.core :as medley]
+            [inferenceql.viz.panels.table.util :refer [merge-row-updates]]
+            [inferenceql.viz.events.interceptors :refer [event-interceptors]]))
 
 (defn set
   "Sets data in the table.
@@ -12,20 +12,34 @@
 
   Args:
     `rows`: A collection of maps to be set as rows in the table.
-    `headers`: The attributes of the maps in `rows` to display in the table."
+    `headers`: The attributes of the maps in `rows` to display in the table. :rowid must be among
+      these attributes as it will be used as the row ids in Handsontable."
   [{:keys [db]} [_ rows headers]]
-  (let [headers (->> headers
-                     ;; The first column should always be the :label column, which will get hidden
-                     ;; and shown by the :table/show-label-column event.
-                     (into [:label]))
+  (let [row-ids (mapv :rowid rows)
+        rows-by-id (medley/index-by :rowid rows)
+
+        headers (->> headers
+                     ;; headers should always look like [:rowid :editable :label ...] because
+                     ;; :rowid, :editable, and :label are automatically added to the
+                     ;; user's query by iql.viz.
+
+                     ;; :rowid should not be displayed in the table. Instead it extracted
+                     ;; from the rows using the Handsontable rowHeaders function.
+                     ;; :editable should also not be displayed.
+
+                     (drop 2) ; drop :rowid and :editable
+                     (vec))
+
         new-db (-> db
-                   (assoc-in [:table-panel :rows] (vec rows))
-                   (assoc-in [:table-panel :headers] headers)
+                   (assoc-in [:table-panel :physical-data :row-ids] row-ids)
+                   (assoc-in [:table-panel :physical-data :rows-by-id] rows-by-id)
+                   (assoc-in [:table-panel :physical-data :headers] headers)
+                   ;; Data at these paths change with updates in the table.
+                   (assoc-in [:table-panel :row-ids] row-ids)
+                   (assoc-in [:table-panel :rows-by-id] rows-by-id)
                    ;; Clear all selections in all selection layers.
                    (assoc-in [:table-panel :selection-layer-coords] {}))]
-    {:db new-db
-     ;; Clear previous selections made in vega-lite plots.
-     :dispatch [:viz/clear-pts-store]}))
+    {:db new-db}))
 
 (rf/reg-event-fx :table/set
                  event-interceptors
@@ -36,10 +50,12 @@
  event-interceptors
  (fn [{:keys [db]} [_]]
    (let [new-db (-> db
-                    (update-in [:table-panel] dissoc :rows :headers)
+                    (update-in [:table-panel] dissoc
+                               :physical-data :visual-state :rows-by-id :row-ids)
                     (assoc-in [:table-panel :selection-layer-coords] {}))]
      {:db new-db
-      :dispatch [:viz/clear-pts-store]})))
+      :fx [[:dispatch [:query/clear-details]]
+           [:dispatch [:viz/clear-pts-store]]]})))
 
 (defn set-hot-instance
   "To be used as re-frame event-db."
@@ -63,3 +79,24 @@
                  event-interceptors
                  (fn [db [_]]
                    (update-in db [:table-panel :show-label-column] not)))
+
+(defn add-row
+  "Adds a new empty row in both the Handsontable instance and the app-db.
+  To be used as a re-frame event-fx.
+
+  Triggered when the user presses the +row button in the control panel UI."
+  [{:keys [db]} [_]]
+  (let [new-rowid (inc (count (get-in db [:table-panel :row-ids])))
+        new-row {:rowid new-rowid :editable true}
+        new-db (-> db
+                   (update-in [:table-panel :rows-by-id] assoc new-rowid new-row)
+                   (update-in [:table-panel :row-ids] conj new-rowid))
+
+        hot (get-in db [:table-panel :hot-instance])]
+    {:db new-db
+     :hot/add-row [hot new-row]
+     :fx [[:dispatch [:control/add-edits-to-query]]]}))
+
+(rf/reg-event-fx :table/add-row
+                 event-interceptors
+                 add-row)

--- a/src/inferenceql/viz/panels/table/handsontable.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable.cljs
@@ -1,15 +1,5 @@
-(ns inferenceql.viz.panels.table.handsontable)
-
-(defn freeze-label-col-pos
-  "Keeps the position of the label column fixed in the table.
-  The label column is meant to always be in the 0-th position.
-  This function is intended to be used as the value of the :beforeColumnMove setting for
-  Handsontable.
-
-  Returns: (bool) Whether to allow the column move or not."
-  [moved-columns _final-index drop-index _move-possible]
-  (and (not-any? #{0} moved-columns) ; The label column is not being moved.
-       (not= drop-index 0))) ; We are not trying to move anything in front of the label column.
+(ns inferenceql.viz.panels.table.handsontable
+  (:require [re-frame.core :as rf]))
 
 (def default-hot-settings
   {:settings {:data                []
@@ -18,7 +8,6 @@
               :rowHeaders          true
               :multiColumnSorting  true
               :manualColumnMove    true
-              :beforeColumnMove    freeze-label-col-pos
               :manualColumnResize  true
               :autoWrapCol         false
               :autoWrapRow         false
@@ -41,10 +30,82 @@
               :licenseKey          "non-commercial-and-evaluation"}
    :hooks []})
 
-;; These keywords refer to events in inferenceql.viz.panels.table.events.
-(def real-hot-hooks [:hot/after-selection-end :hot/after-on-cell-mouse-down
-                     :hot/after-column-move :hot/after-column-sort :hot/after-filter])
+(defn physical-row-indices
+  "Returns the order of physical row indices currently displayed in the handsontable instance.
+
+  Visual indices map to physical indicies (indices of the original dataset sent to handsontable).
+  This mapping changes whenever rows are sorted, filtered, added, or removed.
+
+  We use this data to along with selection coordinates to produce the data subset selected.
+  This all eventually gets passed onto the visualization code via subscriptions."
+  [hot]
+  (let [num-rows-shown (.countRows hot)
+        visual-row-indices (range num-rows-shown)]
+    (map #(.toPhysicalRow hot %) visual-row-indices)))
+
+;; Our hook functions call the associated re-frame event and then return true.  Some
+;; reframe hooks such as :beforeCreateCol (not used) allow the hook function to return
+;; false in order to cancel the event. It is likely that this behaviour exists in
+;; other hooks as well it is just not documented. Returning nil or false from a
+;; callback function can cause errors in handsontable plugins that also have
+;; functions attached to that hook. Therefore, we are always returning true from hook
+;; functions.
+(def real-hot-hooks {:hot/after-selection-end
+                     (fn [hot]
+                       (fn [_row-index _col _row2 _col2 _selection-layer-level]
+                         (rf/dispatch [:hot/after-selection-end
+                                       (js->clj (.getSelected hot))])
+                         true))
+
+                     :hot/after-on-cell-mouse-down
+                     (fn [_]
+                       (fn [mouse-event _coords _TD]
+                         (rf/dispatch [:hot/after-on-cell-mouse-down
+                                       ;; Whether user held alt during last click.
+                                       (js->clj (.-altKey mouse-event))])
+                         true))
+
+                     :hot/after-column-move
+                     (fn [hot]
+                       (fn [_moved-columns _final-index _drop-index _move-possible _order-changed]
+                         (rf/dispatch [:hot/after-column-move
+                                       (js->clj (.getColHeader hot))])
+                         true))
+
+                     :hot/after-column-sort
+                     (fn [hot]
+                       (fn [_current-sort-config _destination-sort-config]
+                         (rf/dispatch [:hot/after-column-sort
+                                       (js->clj (.getColHeader hot))
+                                       (physical-row-indices hot)])
+                         true))
+
+                     :hot/after-create-row
+                     (fn [hot]
+                       (fn [_index _amount source]
+                         (rf/dispatch [:hot/after-create-row
+                                       source
+                                       (physical-row-indices hot)])
+                         true))
+
+                     :hot/after-filter
+                     (fn [hot]
+                       (fn [_conditions-stack]
+                         (rf/dispatch [:hot/after-filter
+                                       (physical-row-indices hot)])
+                         true))
+
+                     :hot/before-change
+                     (fn [_]
+                       (fn [changes source]
+                         ;; For the :hot/before-change event we want to use rf/dispatch-sync, so
+                         ;; that the event handler can run and mutate the changes argument before
+                         ;; returning control to Handsontable. With rf/dispatch, the event will only
+                         ;; be queued and control will immediately return to Handsontable.
+                         (rf/dispatch-sync [:hot/before-change
+                                            changes
+                                            source])
+                         true))})
 
 (def real-hot-settings (-> default-hot-settings
-                           (assoc-in [:hooks] real-hot-hooks)
-                           (assoc-in [:name] "real-table")))
+                           (assoc-in [:hooks] real-hot-hooks)))

--- a/src/inferenceql/viz/panels/table/handsontable_effects.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable_effects.cljs
@@ -1,0 +1,40 @@
+(ns inferenceql.viz.panels.table.handsontable-effects
+  (:require [re-frame.core :as rf]))
+
+(defn add-row
+  "Adds a new row to the Handsontable instance `hot`.
+  To be used as a re-frame fx.
+  Adds the new row, and selects the first cell in that new row (excluding the label column)."
+  [[hot row]]
+  (let [row-index (dec (:rowid row))
+        values (for [[k v] row]
+                 [row-index k v])
+        ;; Table coordinates of the first cell of the new row we are adding.
+        new-selection [[row-index 1 row-index 1]]]
+
+    ;; Remove any sorting the table may have had.
+    (let [sorting-plugin (.getPlugin hot "multiColumnSorting")]
+      (.clearSort sorting-plugin))
+
+    ;; Create the new row.
+    (.alter hot "insert_row" row-index 1 "add-row-fx")
+    ;; Adding data for the new row.
+    (.setSourceDataAtCell hot (clj->js values) nil nil "add-row-fx")
+    ;; Jump to and select the first cell in the newly created row.
+    (.selectCells hot (clj->js new-selection) true)))
+
+(rf/reg-fx :hot/add-row
+           add-row)
+
+(defn select
+  "Selects the cells specified by `selection` in the Handsontable instance `hot`.
+  To be used as a re-frame fx."
+  [[hot selection]]
+  ;; Update selections.
+  (if selection
+    (.selectCells hot (clj->js selection) false)
+    ;; When coords is nil it means nothing should be selected in the table.
+    (.deselectCell hot)))
+
+(rf/reg-fx :hot/select
+           select)

--- a/src/inferenceql/viz/panels/table/handsontable_events.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable_events.cljs
@@ -1,18 +1,22 @@
 (ns inferenceql.viz.panels.table.handsontable-events
   "Re-frame events that correspond to hooks in Handsontable."
   (:require [re-frame.core :as rf]
-            [inferenceql.viz.panels.table.selections :as selections]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
+            [inferenceql.viz.panels.table.selections :as selections]
+            [inferenceql.viz.panels.table.db :as table-db]
+            [inferenceql.viz.panels.table.util :refer [merge-row-updates]]
             [inferenceql.viz.panels.control.db :as control-db]
-            [inferenceql.viz.panels.table.db :as table-db]))
+            [inferenceql.viz.components.query.db :as query-db]
+            [goog.string :refer [format]]
+            [clojure.edn :as edn]))
 
 (rf/reg-event-db
  :hot/after-selection-end
  event-interceptors
- (fn [db [_ hot _id _row-index _col _row2 _col2 _selection-layer-level]]
-   (let [selection-coords (selections/normalize (js->clj (.getSelected hot)))
+ (fn [db [_ selections]]
+   (let [selection-coords (selections/normalize selections)
          color (control-db/selection-color db)
-         num-rows (count (table-db/visual-rows db))]
+         num-rows (count (table-db/visual-row-ids db))]
      (if (selections/valid-selection? selection-coords num-rows)
        (assoc-in db [:table-panel :selection-layer-coords color] selection-coords)
        (update-in db [:table-panel :selection-layer-coords] dissoc color)))))
@@ -20,53 +24,108 @@
 (rf/reg-event-db
   :hot/after-on-cell-mouse-down
   event-interceptors
-  (fn [db [_ _hot _id mouse-event _coords _TD]]
-    (let [alt-key-pressed (.-altKey mouse-event) ;; User held alt during last click.
-          color (control-db/selection-color db)]
+  (fn [db [_ alt-key-pressed]]
+    (let [color (control-db/selection-color db)]
       (cond-> db
         alt-key-pressed
         ;; Deselect all cells in selection layer on alt-click.
         (update-in [:table-panel :selection-layer-coords] dissoc color)))))
 
-(defn assoc-visual-headers
-  "Associates the column headers as displayed by `hot` into `db`.
-  This data changes when the user re-orders columns.
-  We use this data to along with selection coordinates to produce the data subset selected.
-  This all eventually gets passed onto the visualization code via subscriptions."
-  [db hot]
-  (let [headers (mapv keyword (js->clj (.getColHeader hot)))]
-    (assoc-in db [:table-panel :visual-headers] headers)))
-
-(defn assoc-visual-row-data
-  "Associates the actual row data as displayed by `hot` into `db`.
-  The data changes when the user filters or sorts columns.
-  We use this data to along with selection coordinates to produce the data subset selected.
-  This all eventually gets passed onto the visualization code via subscriptions."
-  [db hot]
-  (let [raw-rows (js->clj (.getData hot))
-        rows (for [r raw-rows]
-               (let [remove-nan (fn [cell] (when-not (js/Number.isNaN cell) cell))]
-                 (mapv remove-nan r)))
-        headers (mapv keyword (js->clj (.getColHeader hot)))
-        row-maps (mapv #(zipmap headers %) rows)]
-    (assoc-in db [:table-panel :visual-rows] row-maps)))
-
 (rf/reg-event-db
  :hot/after-column-move
  event-interceptors
- (fn [db [_ hot _id _moved-columns _final-index _drop-index _move-possible _order-changed]]
-   (assoc-visual-headers db hot)))
+ (fn [db [_ headers]]
+   ;; Associates the column headers as displayed by `hot` into `db`. This data changes when the user
+   ;; re-orders columns. We use this data to along with selection coordinates to produce the data
+   ;; subset selected. This all eventually gets passed onto the visualization code via
+   ;; subscriptions.
+   (assoc-in db [:table-panel :visual-state :headers] (mapv keyword headers))))
 
 (rf/reg-event-db
- :hot/after-column-sort
- event-interceptors
- (fn [db [_ hot _id _current-sort-config _destination-sort-config]]
-   (-> db
-       (assoc-visual-row-data hot)
-       (assoc-visual-headers hot))))
+  :hot/after-column-sort
+  event-interceptors
+  (fn [db [_ headers physical-row-indices]]
+    (let [row-ids (get-in db [:table-panel :row-ids])]
+      (-> db
+          (assoc-in [:table-panel :visual-state :headers] (mapv keyword headers))
+          (assoc-in [:table-panel :visual-state :row-ids] (mapv row-ids physical-row-indices))))))
 
 (rf/reg-event-db
- :hot/after-filter
- event-interceptors
- (fn [db [_ hot _id _conditions-stack]]
-   (assoc-visual-row-data db hot)))
+  :hot/after-create-row
+  event-interceptors
+  (fn [db [_ source physical-row-indices]]
+    (assert (= source "add-row-fx"))
+    (let [row-ids (get-in db [:table-panel :row-ids])]
+      (assoc-in db [:table-panel :visual-state :row-ids] (mapv row-ids physical-row-indices)))))
+
+(rf/reg-event-db
+  :hot/after-filter
+  event-interceptors
+  (fn [db [_ physical-row-indices]]
+    (let [row-ids (get-in db [:table-panel :row-ids])]
+      (assoc-in db [:table-panel :visual-state :row-ids] (mapv row-ids physical-row-indices)))))
+
+(rf/reg-event-fx
+  :hot/before-change
+  event-interceptors
+  ;; This event mutates the changes argument (which is a js-object producted by Handsontable).
+  ;; Certain types of mutations allows this event to cancel changes in Handsontable. This approach
+  ;; is not the ideal re-frame way.
+  (fn [{:keys [db]} [_ changes source]]
+    (let [valid-change-sources #{"edit" "CopyPaste.paste" "Autofill.fill" "UndoRedo.undo"}]
+      ;; Changes should only be the result of user edits, copy paste, drag and autofill,
+      ;; and undo. This should be enforced by Hansontable settings.
+      (assert (some? (valid-change-sources source))))
+    (let [{:keys [updates errors]}
+          (reduce (fn [acc [i change]]
+                    (let [[row col _prev-val new-val] change
+                          row-id (get (table-db/visual-row-ids db) row)
+                          col (keyword col)
+                          editable (get-in db [:table-panel :rows-by-id row-id :editable])
+                          type (get (query-db/schema-base db) col)]
+
+                      ;; Changes should only occur in the label column or in editable row.
+                      (assert (or (= col :label) editable))
+
+                      (cond
+                        (= type :gaussian)
+                        ;; Try to cast.
+                        (let [new-val (edn/read-string new-val)]
+                          (if (or (number? new-val) (nil? new-val))
+                            ;; Include the change.
+                            (assoc-in acc [:updates row-id col] new-val)
+                            (do
+                              ;; Cancel this change.
+                              (aset changes i nil)
+                              (let [error (format
+                                           (str "The value '%s' is not a number. "
+                                                "New values for column '%s' must be a number.")
+                                           new-val (name col))]
+                                ;; Do not include the change. Add the error.
+                                (update acc :errors conj error)))))
+
+                        (or (= type :categorical) (= col :label))
+                        ;; Just include the change.
+                        (assoc-in acc [:updates row-id col] new-val)
+
+                        :else
+                        (do
+                          ;; Cancel this change.
+                          (aset changes i nil)
+                          ;; Trying to edit a column that is either not in the original
+                          ;; dateset's schema or the column has been renamed in the query.
+                          (let [error (format
+                                       (str "Column '%s' is not part of the original dataset. "
+                                            "You can not edit its values.")
+                                       (name col))]
+                            (update acc :errors conj error))))))
+
+                  {:updates {} :errors []}
+                  (map-indexed vector changes))
+          ;; Re-frame :fx vectors
+          errors (vec (for [error errors]
+                        [:js/console-error error]))]
+      ;; Add the changes to db. Handsontable itself already has the updates.
+      {:db (update-in db [:table-panel :rows-by-id] merge-row-updates updates)
+       :fx (conj errors
+                 [:dispatch [:control/add-edits-to-query]])})))

--- a/src/inferenceql/viz/panels/table/subs.cljs
+++ b/src/inferenceql/viz/panels/table/subs.cljs
@@ -6,8 +6,9 @@
             [inferenceql.viz.panels.table.renderers :as rends]
             [inferenceql.viz.panels.table.handsontable :as hot]
             [inferenceql.viz.panels.table.selections :as selections]
-            [inferenceql.viz.panels.table.db :as db]
-            [inferenceql.viz.panels.override.views :as modal]))
+            [inferenceql.viz.util :refer [coerce-bool]]
+            [inferenceql.viz.panels.table.util :refer [merge-row-updates]]
+            [goog.string :refer [format]]))
 
 ;;; Subs related selection layer color.
 
@@ -60,14 +61,30 @@
 
 ;;; Subs related to populating tables with data.
 
-(rf/reg-sub :table/table-headers
+(rf/reg-sub :table/physical-data
             (fn [db _]
-              (db/table-headers db)))
+              (get-in db [:table-panel :physical-data])))
 
-(defn table-rows
-  [db _]
-  (db/table-rows db))
-(rf/reg-sub :table/table-rows table-rows)
+(rf/reg-sub :table/physical-headers
+            :<- [:table/physical-data]
+            (fn [physical-data]
+              (get physical-data :headers)))
+
+(rf/reg-sub :table/physical-row-ids
+            :<- [:table/physical-data]
+            (fn [physical-data]
+              (get physical-data :row-ids)))
+
+(rf/reg-sub :table/physical-rows-by-id
+            :<- [:table/physical-data]
+            (fn [physical-data]
+              (get physical-data :rows-by-id)))
+
+(rf/reg-sub :table/physical-rows
+            :<- [:table/physical-row-ids]
+            :<- [:table/physical-rows-by-id]
+            (fn [[row-ids rows-by-id]]
+              (mapv rows-by-id row-ids)))
 
 (defn- display-headers
   "Returns an sequence of strings for column name headers to display.
@@ -90,22 +107,50 @@
                        {:data attr})]
     (map settings-map headers)))
 
-;;; Subs related to visual state of the table
+;;; Subs related to data in handsontable with various user edits incorporated.
+
+(rf/reg-sub :table/rows-by-id
+            (fn [db _]
+              (get-in db [:table-panel :rows-by-id])))
+
+(rf/reg-sub :table/row-ids
+            (fn [db _]
+              (get-in db [:table-panel :row-ids])))
+
+(rf/reg-sub :table/rows
+            :<- [:table/row-ids]
+            :<- [:table/rows-by-id]
+            (fn [[row-ids rows-by-id]]
+              (mapv rows-by-id row-ids)))
+
+;;; Subs related to visual state of the table.
+
+(rf/reg-sub :table/visual-state
+            (fn [db _]
+              (get-in db [:table-panel :visual-state])))
 
 (rf/reg-sub :table/visual-headers
-            (fn [db _]
-              (get-in db [:table-panel :visual-headers])))
+            :<- [:table/visual-state]
+            (fn [visual-state]
+              (get visual-state :headers)))
+
+(rf/reg-sub :table/visual-row-ids
+            :<- [:table/visual-state]
+            (fn [visual-state]
+              (get visual-state :row-ids)))
 
 (rf/reg-sub :table/visual-rows
-            (fn [db _]
-              (get-in db [:table-panel :visual-rows])))
+            :<- [:table/visual-row-ids]
+            :<- [:table/rows-by-id]
+            (fn [[row-ids rows-by-id]]
+              (mapv rows-by-id row-ids)))
 
 (rf/reg-sub :table/selected-row-flags
-            :<- [:table/table-rows]
+            :<- [:table/rows]
             :<- [:viz/pts-store-filter]
             (fn [[rows pts-store-filter]]
               (when pts-store-filter
-                (map pts-store-filter rows))))
+                (mapv pts-store-filter rows))))
 
 ;;; Subs related showing/hiding certain columns or table controls.
 
@@ -118,7 +163,7 @@
     "hidden"))
 
 (rf/reg-sub :table/show-table-controls
-            :<- [:table/table-rows]
+            :<- [:table/rows]
             show-table-controls)
 
 (rf/reg-sub :table/show-label-column
@@ -146,78 +191,64 @@
   Provides special styling for rows selected through vega-lite visualizations."
   [selected-row-flags]
   (fn [row _col prop]
-    (let [selected (when row (nth selected-row-flags row))
-          label-column-cell (= prop (name :label))
+    (this-as obj
+      (let [hot (.-instance obj)
+            editable (true? (.getDataAtRowProp hot row (name :editable)))
+            selected (when row (nth selected-row-flags row false))
+            label-column-cell (= prop (name :label))
 
-          class-names [(when selected "selected-row")
-                       (when label-column-cell "label-cell")]
-          class-names-string (str/join ", " (remove nil? class-names))]
-      #js {:className class-names-string
-           ;; Make cells in the :label column editable
-           :readOnly (not label-column-cell)})))
+            class-names [(when editable "editable-cell")
+                         (when selected "selected-row")
+                         (when label-column-cell "label-cell")]
+            class-names-string (str/join " " (remove nil? class-names))
+
+            ;; Make the :label column editable.
+            ;; Make editable row editable.
+            read-only (and (not label-column-cell) (not editable))]
+        #js {:className class-names-string
+             :readOnly read-only}))))
 
 (rf/reg-sub :table/cells
             :<- [:table/selected-row-flags]
             cells)
 
+(defn row-headers
+  "Returns a function to be used as the rowHeaders option in Handsontable.
+  To be used as a re-frame subscription."
+  [hot]
+  (fn [row-physical-index]
+    (let [v-row (.toVisualRow hot row-physical-index)]
+      (.getDataAtRowProp hot v-row (name :rowid)))))
+
+(rf/reg-sub :table/row-headers
+            :<- [:table/hot-instance]
+            row-headers)
+
+(def context-menu
+  {:items {"incorp_new_vals" {:disabled false
+                              :name "INCORPORATE all new values into model"
+                              :callback (fn [_key _selection _click-event]
+                                          (rf/dispatch [:control/incorp-new-vals-in-query]))}}})
+
 (defn ^:sub real-hot-props
-  [[headers rows context-menu cells hidden-columns selection-coords-active]]
+  [[table-headers row-headers rows cells hidden-columns selection-coords-active]]
   (-> hot/real-hot-settings
       (assoc-in [:settings :data] rows)
-      (assoc-in [:settings :colHeaders] (display-headers headers))
-      (assoc-in [:settings :columns] (column-settings headers))
+      (assoc-in [:settings :colHeaders] (display-headers table-headers))
+      (assoc-in [:settings :columns] (column-settings table-headers))
+      (assoc-in [:settings :rowHeaders] row-headers)
       (assoc-in [:settings :cells] cells)
       (assoc-in [:settings :contextMenu] context-menu)
       (assoc-in [:settings :hiddenColumns] hidden-columns)
       (assoc-in [:selections-coords] selection-coords-active)))
 (rf/reg-sub :table/real-hot-props
-            :<- [:table/table-headers]
-            :<- [:table/table-rows]
-            :<- [:table/context-menu]
+            :<- [:table/physical-headers]
+            :<- [:table/row-headers]
+            :<- [:table/physical-rows]
             :<- [:table/cells]
             :<- [:table/hidden-columns]
             :<- [:table/selection-coords-active]
             real-hot-props)
-
-(rf/reg-sub
- :table/context-menu
- (fn [_ _]
-   {:col-overrides (rf/subscribe [:override/column-overrides])
-    :col-names (rf/subscribe [:table/table-headers])})
- (fn [{:keys [col-overrides col-names]}]
-   (let [set-function-fn (fn [key selection click-event]
-                           (this-as hot
-                             (let [last-col-num (.. (first selection) -start -col)
-                                   last-col-num-phys (.toPhysicalColumn hot last-col-num)
-                                   col-name (nth col-names last-col-num-phys)
-                                   fn-text (get col-overrides col-name)
-
-                                   modal-child [modal/js-function-entry-modal col-name fn-text]]
-                               (rf/dispatch [:override/set-modal {:child modal-child}]))))
-
-         clear-function-fn (fn [key selection click-event]
-                             (this-as hot
-                               (let [last-col-num (.. (first selection) -start -col)
-                                     last-col-num-phys (.toPhysicalColumn hot last-col-num)
-                                     col-name (nth col-names last-col-num-phys)]
-                                 (rf/dispatch [:override/clear-column-function col-name]))))
-
-         disable-fn (fn []
-                     (this-as hot
-                       (let [last-selected (.getSelectedRangeLast hot)
-                             from-col (.. last-selected -from -col)
-                             to-col (.. last-selected -to -col)
-                             from-row (.. last-selected -from -row)]
-
-                         ;; Disable the menu when either more than one column is selected
-                         ;; or when the selection does not start from a cell in the header row.
-                         (or (not= from-col to-col) (not= from-row 0)))))]
-     {:items {"set_function" {:disabled disable-fn
-                              :name "Set js function"
-                              :callback set-function-fn}
-              "clear_function" {:disabled disable-fn
-                                :name "Clear js function"
-                                :callback clear-function-fn}}})))
 
 (rf/reg-sub
  :table/cells-style-fn
@@ -235,7 +266,7 @@
     :missing-cells-flagged (rf/subscribe [:highlight/missing-cells-flagged])
     :conf-thresh (rf/subscribe [:control/confidence-threshold])
     :conf-mode (rf/subscribe [:control/reagent-form [:confidence-mode]])
-    :computed-headers (rf/subscribe [:table/table-headers])})
+    :computed-headers (rf/subscribe [:table/physical-headers])})
  ;; Returns a cell renderer function used by Handsontable.
  (fn [{:keys [row-likelihoods missing-cells-flagged conf-thresh conf-mode computed-headers]}]
    (case conf-mode

--- a/src/inferenceql/viz/panels/table/util.cljs
+++ b/src/inferenceql/viz/panels/table/util.cljs
@@ -1,0 +1,9 @@
+(ns inferenceql.viz.panels.table.util)
+
+(defn merge-row-updates
+  "Merges `updates` into `rows`.
+  Both `updates` and `rows` are a maps where keys are row-ids and vals are rows
+  (or row updates) in the case of `updates`."
+  [rows updates]
+  (let [merge-op (fnil (partial merge-with merge) {} {})]
+    (merge-op rows updates)))

--- a/src/inferenceql/viz/panels/upload/events.cljs
+++ b/src/inferenceql/viz/panels/upload/events.cljs
@@ -149,6 +149,7 @@
       ;; TODO: Check datasets, schemas, and geodata against spec before storing.
       {:fx [[:dispatch [:store/datasets datasets]]
             [:dispatch [:store/models models]]
+            [:dispatch [:control/set-query-string-to-select-all]]
             (when (seq geodata) [:dispatch [:store/geodata geodata]])]})
     (catch js/Error e
       {:fx [[:dispatch [:upload/read-failed (str "Error processing reads.\n" (.-stack e))]]]})))

--- a/src/inferenceql/viz/panels/viz/events.cljs
+++ b/src/inferenceql/viz/panels/viz/events.cljs
@@ -33,4 +33,4 @@
   :viz/clear-pts-store
   event-interceptors
   (fn [db _]
-    (update-in db [:viz-panel] dissoc :pts-store)))
+    (update-in db [:viz-panel] dissoc :pts-store :pts-store-staged)))

--- a/src/inferenceql/viz/panels/viz/vega.cljs
+++ b/src/inferenceql/viz/panels/viz/vega.cljs
@@ -54,10 +54,11 @@
        s))
 
 (defn probability-column? [col-name]
-  "Returns whether a `col-name` was the result of probability-of statement.
+  "Returns whether a `col-name` was the result of PROBABILITY OF statement
+  or PROBABILITY DENSITY OF statement and was not rebinded with an AS label.
   `col-name` is the name of the column."
   (when col-name
-    (some? (re-matches #"^prob[\w\-]*$" (name col-name)))))
+    (some? (re-matches #"^density[\d]*$" (name col-name)))))
 
 (defn vega-type-fn
   "Given a `schema`, returns a vega-type function.
@@ -289,9 +290,11 @@
                        :zoom "wheel![!event.shiftKey]"
                        :empty "none"}}
      :encoding {:x {:field (first cols-to-draw)
-                    :type "quantitative"}
+                    :type "quantitative"
+                    :scale {:zero false}}
                 :y {:field (second cols-to-draw)
-                    :type "quantitative"}
+                    :type "quantitative"
+                    :scale {:zero false}}
                 :color {:condition {:selection "pts"
                                     :value selection-color}}}}))
 
@@ -377,7 +380,9 @@
                        :empty "none"}}
      :encoding {:x {:field x-field
                     :type x-type
-                    :axis {:grid true :gridDash [2 2]}}
+                    :axis {:grid true :gridDash [2 2]}
+                    ;; Note: this assumes the x-axis is quantitative.
+                    :scale {:zero false}}
                 :y {:field y-field
                     :type y-type
                     :axis {:grid true :gridDash [2 2]}}

--- a/src/inferenceql/viz/util.cljc
+++ b/src/inferenceql/viz/util.cljc
@@ -1,6 +1,7 @@
 (ns inferenceql.viz.util
   (:require [medley.core :as medley]
-            [lambdaisland.uri :refer [query-map]]))
+            [lambdaisland.uri :refer [query-map]]
+            [clojure.string :as str]))
 
 (defn filter-nil-kvs [a-map]
   (into {} (remove (comp nil? val) a-map)))
@@ -24,3 +25,11 @@
   (let [app-url #?(:cljs (.-location js/window)
                    :clj nil)]
     (query-map app-url {:multikeys :never})))
+
+(defn coerce-bool [val]
+  (case (str/lower-case (str val))
+    "true" true
+    "t" true
+    "false" false
+    "f" false
+    nil))

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,9 +251,11 @@ core-util-is@~1.0.0:
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
 "d3-array@1 - 2", d3-array@>=2.5, d3-array@^2.3.0, d3-array@^2.7.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.9.1.tgz#f355cc72b46c8649b3f9212029e2d681cb5b9643"
-  integrity sha512-Ob7RdOtkqsjx1NWyQHMFLtCSk6/aKTxDdC4ZIolX+O+mDD2RzrsYgAyc0WGAlfYFVELLSilS7w8BtE3PKM8bHg==
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.12.0.tgz#68a74d153e52d6bf4608d9f6388cca48b42a4c3f"
+  integrity sha512-T6H/qNldyD/1OlRkJbonb3u3MPhNwju8OPxYv0YSjDb/B2RUeeBEHzIpNrYiinwpmz8+am+puMrpcrDWgY9wRg==
+  dependencies:
+    internmap "^1.0.0"
 
 "d3-color@1 - 2", d3-color@^2.0.0:
   version "2.0.0"
@@ -346,9 +348,9 @@ d3-scale@^3.2.2:
     d3-time-format "2 - 3"
 
 d3-shape@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-2.0.0.tgz#2331b62fa784a2a1daac47a7233cfd69301381fd"
-  integrity sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-2.1.0.tgz#3b6a82ccafbc45de55b57fcf956c584ded3b666f"
+  integrity sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==
   dependencies:
     d3-path "1 - 2"
 
@@ -520,6 +522,11 @@ inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+internmap@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -931,12 +938,17 @@ vega-encode@~4.8.3:
     vega-scale "^7.0.3"
     vega-util "^1.15.2"
 
-vega-event-selector@^2.0.6, vega-event-selector@~2.0.3, vega-event-selector@~2.0.6:
+vega-event-selector@^2.0.6, vega-event-selector@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-2.0.6.tgz#6beb00e066b78371dde1a0f40cb5e0bbaecfd8bc"
   integrity sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew==
 
-vega-expression@^4.0.0, vega-expression@^4.0.1, vega-expression@~4.0.1:
+vega-event-selector@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-2.0.3.tgz#760c61af7ab5c325d3274fd3ab284d067ff16f8c"
+  integrity sha512-rUnAvBSy5tkk+0MELY7qICTgjMNjH/DDNIH603q3GRi+bBRCd4MlJxWrPYBhwZIYpmr6XCe130lZ90/F5SgVfA==
+
+vega-expression@^4.0.1, vega-expression@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-4.0.1.tgz#c03e4fc68a00acac49557faa4e4ed6ac8a59c5fd"
   integrity sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==
@@ -970,10 +982,10 @@ vega-format@^1.0.4, vega-format@~1.0.4:
     vega-time "^2.0.3"
     vega-util "^1.15.2"
 
-vega-functions@^5.10.0, vega-functions@~5.10.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.10.0.tgz#3d384111f13b3b0dd38a4fca656c5ae54b66e158"
-  integrity sha512-1l28OxUwOj8FEvRU62Oz2hiTuDECrvx1DPU1qLebBKhlgaKbcCk3XyHrn1kUzhMKpXq+SFv5VPxchZP47ASSvQ==
+vega-functions@^5.10.0, vega-functions@^5.12.0, vega-functions@~5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/vega-functions/-/vega-functions-5.12.0.tgz#44bf08a7b20673dc8cf51d6781c8ea1399501668"
+  integrity sha512-3hljmGs+gR7TbO/yYuvAP9P5laKISf1GKk4yRHLNdM61fWgKm8pI3f6LY2Hvq9cHQFTiJ3/5/Bx2p1SX5R4quQ==
   dependencies:
     d3-array "^2.7.1"
     d3-color "^2.0.0"
@@ -981,8 +993,8 @@ vega-functions@^5.10.0, vega-functions@~5.10.0:
     vega-dataflow "^5.7.3"
     vega-expression "^4.0.1"
     vega-scale "^7.1.1"
-    vega-scenegraph "^4.9.2"
-    vega-selections "^5.1.5"
+    vega-scenegraph "^4.9.3"
+    vega-selections "^5.3.0"
     vega-statistics "^1.7.9"
     vega-time "^2.0.4"
     vega-util "^1.16.0"
@@ -1049,16 +1061,16 @@ vega-loader@^4.3.2, vega-loader@^4.3.3, vega-loader@~4.4.0:
     vega-format "^1.0.4"
     vega-util "^1.16.0"
 
-vega-parser@~6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.1.2.tgz#7f25751177e38c3239560a9c427ded8d2ba617bb"
-  integrity sha512-aGyZrNzPrBruEb/WhemKDuDjQsIkMDGIgnSJci0b+9ZVxjyAzMl7UfGbiYorPiJlnIercjUJbMoFD6fCIf4gqQ==
+vega-parser@~6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-6.1.3.tgz#df72785e4b086eceb90ee6219a399210933b507b"
+  integrity sha512-8oiVhhW26GQ4GZBvolId8FVFvhn3s1KGgPlD7Z+4P2wkV+xe5Nqu0TEJ20F/cn3b88fd0Vj48X3BH3dlSeKNFg==
   dependencies:
     vega-dataflow "^5.7.3"
     vega-event-selector "^2.0.6"
-    vega-functions "^5.10.0"
+    vega-functions "^5.12.0"
     vega-scale "^7.1.1"
-    vega-util "^1.15.2"
+    vega-util "^1.16.0"
 
 vega-projection@^1.4.5, vega-projection@~1.4.5:
   version "1.4.5"
@@ -1097,10 +1109,10 @@ vega-scale@^7.0.3, vega-scale@^7.1.1, vega-scale@~7.1.1:
     vega-time "^2.0.4"
     vega-util "^1.15.2"
 
-vega-scenegraph@^4.9.2, vega-scenegraph@~4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.9.2.tgz#83b1dbc34a9ab5595c74d547d6d95849d74451ed"
-  integrity sha512-epm1CxcB8AucXQlSDeFnmzy0FCj+HV2k9R6ch2lfLRln5lPLEfgJWgFcFhVf5jyheY0FSeHH52Q5zQn1vYI1Ow==
+vega-scenegraph@^4.9.2, vega-scenegraph@^4.9.3, vega-scenegraph@^4.9.4, vega-scenegraph@~4.9.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/vega-scenegraph/-/vega-scenegraph-4.9.4.tgz#468408c1e89703fa9d3450445daabff623de2757"
+  integrity sha512-QaegQzbFE2yhYLNWAmHwAuguW3yTtQrmwvfxYT8tk0g+KKodrQ5WSmNrphWXhqwtsgVSvtdZkfp2IPeumcOQJg==
   dependencies:
     d3-path "^2.0.0"
     d3-shape "^2.0.0"
@@ -1114,13 +1126,13 @@ vega-schema-url-parser@^1.1.0:
   resolved "https://registry.yarnpkg.com/vega-schema-url-parser/-/vega-schema-url-parser-1.1.0.tgz#39168ec04e5468ce278a06c16ec0d126035a85b5"
   integrity sha512-Tc85J2ofMZZOsxiqDM9sbvfsa+Vdo3GwNLjEEsPOsCDeYqsUHKAlc1IpbbhPLZ6jusyM9Lk0e1izF64GGklFDg==
 
-vega-selections@^5.1.5:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.1.5.tgz#c7662edf26c1cfb18623573b30590c9774348d1c"
-  integrity sha512-oRSsfkqYqA5xfEJqDpgnSDd+w0k6p6SGYisMD6rGXMxuPl0x0Uy6RvDr4nbEtB+dpWdoWEvgrsZVS6axyDNWvQ==
+vega-selections@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/vega-selections/-/vega-selections-5.3.0.tgz#810f2e7b7642fa836cf98b2e5dcc151093b1f6a7"
+  integrity sha512-vC4NPsuN+IffruFXfH0L3i2A51RgG4PqpLv85TvrEAIYnSkyKDE4bf+wVraR3aPdnLLkc3+tYuMi6le5FmThIA==
   dependencies:
-    vega-expression "^4.0.0"
-    vega-util "^1.15.2"
+    vega-expression "^4.0.1"
+    vega-util "^1.16.0"
 
 vega-statistics@^1.7.9, vega-statistics@~1.7.9:
   version "1.7.9"
@@ -1161,22 +1173,27 @@ vega-transforms@~4.9.3:
     vega-time "^2.0.4"
     vega-util "^1.15.2"
 
-vega-typings@~0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.19.2.tgz#374fc1020c1abb263a0be87de28d1a4bd0526c3f"
-  integrity sha512-YU/S9rDk4d+t4+4eTa9fzuw87PMNteeVtpcL51kUO8H7HvGaoW7ll8RHKLkR0NYBEGPRoFDKUxnoyMvhgjsdYw==
+vega-typings@~0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/vega-typings/-/vega-typings-0.20.0.tgz#aac32f45ca69d3640d205ffdd9cd94fe1d6dcc19"
+  integrity sha512-S+HIRN/3WYiS5zrQjJ4FDEOlvFVHLxPXMJerrnN3YZ6bxCDYo7tEvQUUuByGZ3d19GuKjgejczWS7XHvF3WjDw==
   dependencies:
     vega-util "^1.15.2"
 
-vega-util@^1.13.2, vega-util@^1.14.0, vega-util@^1.15.2, vega-util@^1.16.0, vega-util@~1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.16.0.tgz#77405d8df0a94944d106bdc36015f0d43aa2caa3"
-  integrity sha512-6mmz6mI+oU4zDMeKjgvE2Fjz0Oh6zo6WGATcvCfxH2gXBzhBHmy5d25uW5Zjnkc6QBXSWPLV9Xa6SiqMsrsKog==
+vega-util@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.13.2.tgz#d9fe2378f0e780290e231d128d8c125407fb3559"
+  integrity sha512-cN/VaO8CjPb3ELfQb+IVi5NGoQpYhWSUFfH7K2ibwagO8obZlUFa9ze8fYiexi2Txf78HFgWm9MXNdV6PROrkw==
 
-vega-util@~1.14.0:
+vega-util@^1.14.0, vega-util@~1.14.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.14.1.tgz#0fb614277764f98738ba0b80e5cdfbe663426183"
   integrity sha512-pSKJ8OCkgfgHZDTljyj+gmGltgulceWbk1BV6LWrXqp6P3J8qPA/oZA8+a93YNApYxXZ3yzIVUDOo5O27xk0jw==
+
+vega-util@^1.15.2, vega-util@^1.16.0, vega-util@^1.16.1, vega-util@~1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.16.1.tgz#992bf3c3b6e145797214d99862841baea417ba39"
+  integrity sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg==
 
 vega-view-transforms@~4.5.8:
   version "4.5.8"
@@ -1187,10 +1204,10 @@ vega-view-transforms@~4.5.8:
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
 
-vega-view@~5.9.2:
-  version "5.9.2"
-  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.9.2.tgz#cb957e481a952abbe7b3a11aa2d58cc728f295e7"
-  integrity sha512-XAwKWyVjLClR3aCbTLCWdZj7aZozOULNg7078GxJIgVcBJOENCAidceI/H7JieyUZ96p3AiEHLQdWr167InBpg==
+vega-view@~5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-5.10.0.tgz#12ce02d8f58151bf10211d2ac4c65cf35a1ef1f4"
+  integrity sha512-HuqTVimMqlgqe64EQkTEnt0+yDkt29/q1szg/m9QwCrSc5QMXI8Mkt58O/F7OD3QyVr7xrKHyPTk9I9gCaZ6sw==
   dependencies:
     d3-array "^2.7.1"
     d3-timer "^2.0.0"
@@ -1198,8 +1215,8 @@ vega-view@~5.9.2:
     vega-format "^1.0.4"
     vega-functions "^5.10.0"
     vega-runtime "^6.1.3"
-    vega-scenegraph "^4.9.2"
-    vega-util "^1.15.2"
+    vega-scenegraph "^4.9.4"
+    vega-util "^1.16.1"
 
 vega-voronoi@~4.1.5:
   version "4.1.5"
@@ -1222,9 +1239,9 @@ vega-wordcloud@~4.1.3:
     vega-util "^1.15.2"
 
 vega@^5.17.3:
-  version "5.17.3"
-  resolved "https://registry.yarnpkg.com/vega/-/vega-5.17.3.tgz#9901f24c8cf5ff2e98f3fddb372b8f5a6d8502d8"
-  integrity sha512-c8N2pNg9MMmC6shNpoxVw3aVp2XPFOgmWNX5BEOAdCaGHRnSgzNy44+gYdGRaIe6+ljTzZg99Mf+OLO50IP42A==
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/vega/-/vega-5.20.0.tgz#8be803391c9441d569a72531917b69d62edb5e57"
+  integrity sha512-L2hDaTH2gz9DFbu7l1B8fR637HzctViuosFCo/Db5aBe93fCJ/w/oJu+vQNfQELzfm9sntkS/+A4u+39xrDCNA==
   dependencies:
     vega-crossfilter "~4.0.5"
     vega-dataflow "~5.7.3"
@@ -1233,23 +1250,23 @@ vega@^5.17.3:
     vega-expression "~4.0.1"
     vega-force "~4.0.7"
     vega-format "~1.0.4"
-    vega-functions "~5.10.0"
+    vega-functions "~5.12.0"
     vega-geo "~4.3.8"
     vega-hierarchy "~4.0.9"
     vega-label "~1.0.0"
     vega-loader "~4.4.0"
-    vega-parser "~6.1.2"
+    vega-parser "~6.1.3"
     vega-projection "~1.4.5"
     vega-regression "~1.0.9"
     vega-runtime "~6.1.3"
     vega-scale "~7.1.1"
-    vega-scenegraph "~4.9.2"
+    vega-scenegraph "~4.9.4"
     vega-statistics "~1.7.9"
     vega-time "~2.0.4"
     vega-transforms "~4.9.3"
-    vega-typings "~0.19.2"
-    vega-util "~1.16.0"
-    vega-view "~5.9.2"
+    vega-typings "~0.20.0"
+    vega-util "~1.16.1"
+    vega-view "~5.10.0"
     vega-view-transforms "~4.5.8"
     vega-voronoi "~4.1.5"
     vega-wordcloud "~4.1.3"


### PR DESCRIPTION
## What does this do?

Many changes to enable FSL

- Update iql dependencies.
- Edit all queries before executing with iql.query (add columns: rowid, label)
- Generate a `select all query` using columns in the schema and add the query to the query textbox on startup or whenever the dataset is changed. (This is to the deal with not being able todo `SELECT rowid, * FROM data;`
- Use iql.query rowids as rowheaders in Handsontable
- Use iql.query rowids to store rows in app-db. (under `rows-by-id` and `row-ids` and the same keys under `:physical-data`)
- Reorganize keys for storing information about data in Handsontable, visual state in Handsontable, and changes made in the table UI.
    - `physical-data` - Keys related to data sent to the Handsontable reagent component. Changing any of these keys will cause Handsontable to update.
    - `visual-state` - Keys related to the visual state of Handsontable. Takes into account columns moves, filtering, sorting, etc. Updated by various Handsontable hooks.
    - `rows-by-id` - Contains the same data as `[:physical-data :rows-by-id]` but also contains changes to the table made in the UI. (labels, and data in new-rows). Updated by the `:hot/before-change` hook and the `:table/add-row` event.
    - `row-ids` - Contains the same data as `[:physical-data :row-ids]` but also contains row-ids for new rows added in the UI. Updated by the `:table/add-row` event.
- Make query component store a bunch of additional information about a query when it's executed.
- Add `:hot/before-change` event for capturing edits made in Handsontable.
- Add `:table/add-row` event for adding a new row to the dataset and Handsontable.
- Add re-frame effects for making selections in Handsontable and for adding a row.
- Change selections in Handsontable via a re-frame effect instead of via a subscription passed into the reagent component.
- Change how Handsontable hooks call their respective re-frame events. Previously this was done by passing the whole Handsontable object into the event vector along with the hook arguments, but now we extract only the necessary data from the Handsontable object and pass that in. This prevents state changing from underneath events.
- Add query editing functions for reflecting dataset changes made in Handsontable and for incorporating those changes into models.
- Use a query editing function in the `:hot/before-change` and `:table/add-row` events to automatically update the query string for changes to the label column or new rows.
- Add a right click menu with an option for updating the query string with datasets changes INCORPORATED into any models present in the query.

And 

- Make very small un-related fixes for viz code

## How to test

Use the beat19 dataset and model by applying this patch. 
[0001-Add-beat-19-items.patch.zip](https://github.com/probcomp/inferenceql.viz/files/6238423/0001-Add-beat-19-items.patch.zip)

Then run some of the queries found here.
https://gist.github.com/harishtella/4e9d44a9d98a3154298e01d08a48dcc3

