### PR TITLE
Cache dependencies in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,6 @@ jobs:
         with:
           path: ~/.gitlibs
           key: gitlibs-${{ hashFiles('deps.edn') }}
-
       - name: Prepare dependencies
         run: clojure -A:test -P
       - name: Run tests


### PR DESCRIPTION
## What does this do?

Caches the project's Clojure dependencies after each continuous integration run.

## Why should we do this?

Run duration of the tests action:

| Cache miss | Cache hit |
|-|-|
|  2m 6s | 1m 10s |