### PR TITLE
Add ability to read query string from url param

### DIFF
--- a/src/inferenceql/viz/core.cljs
+++ b/src/inferenceql/viz/core.cljs
@@ -65,6 +65,14 @@
   ;; We only initialize the app-db on first load. This is so figwheel's hot code reloading does
   ;; not reset the state of the app.
   (rf/dispatch-sync [:app/initialize-db])
-  (rf/dispatch-sync [:upload/read-query-string-params (query-string-params)])
-  (rf/dispatch-sync [:control/set-query-string-to-select-all])
+
+  (let [params (query-string-params)]
+    (rf/dispatch-sync [:upload/read-query-string-params params])
+
+    (if (:query params)
+      ;; Use the query string passed in params.
+      (rf/dispatch-sync [:control/set-query-string (:query params)])
+      ;; Set the query string to select all columns.
+      (rf/dispatch-sync [:control/set-query-string-to-select-all])))
+
   (render-app))


### PR DESCRIPTION
## What does this do?

It lets the user pass in a query (via a url param) that the app will load into the query textbox on startup.

## How to test?

Try launching the app with url in your browser that looks like `.....index.html?query=SELECT age FROM data;`

NOTE: the query string will have to be url encoded for more complex queries such as ones that have newlines. 