### PR TITLE
Change name of eval binding

### DIFF
--- a/src/inferenceql/viz/components/query/editing.cljc
+++ b/src/inferenceql/viz/components/query/editing.cljc
@@ -130,11 +130,11 @@
                            (tree/get-node-in [:table-expr :ref])
                            (query/unparse))
 
-        eval #(query/eval % {})
+        q-eval #(query/eval % {})
         set-map-exprs (some-> update-expr
                               (tree/get-node-in [:set-clause :map-expr])
                               (tree/child-nodes))
-        set-map (apply merge (map eval set-map-exprs))
+        set-map (apply merge (map q-eval set-map-exprs))
 
         where-pairs  (some-> update-expr
                              (tree/get-node-in [:where-clause :or-condition])


### PR DESCRIPTION
## What does this do?

Changes the name of a binding.

## Motivation 

The binding name `eval` causes an error during Clojurescript advanced compilation. 