### PR TITLE
Inline more icon

### DIFF
--- a/src/inferenceql/viz/panels/more/views.cljs
+++ b/src/inferenceql/viz/panels/more/views.cljs
@@ -6,6 +6,18 @@
             [inferenceql.viz.panels.jsmodel.views :as jsmodel.views]
             [inferenceql.viz.panels.upload.views :as upload.views]))
 
+(def more-icon-inlined
+  "This is an inlined version of the icon located at resources/icons/more_vert-24px.svg
+  Inlining the icon allows for more easily inlined the entire iql.viz app into a single html file."
+  
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'
+  height='24' viewBox='0 0 24 24' width='24'%3E%3Cstyle type='text/css'
+  %3E%3C!%5BCDATA%5B .more-icon-dots %7B fill: %23AAA; %7D
+  %5D%5D%3E%3C/style%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3Cpath
+  class='more-icon-dots' d='M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9
+  2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2
+  .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z'/%3E%3C/svg%3E")
+
 (defn more-button
   "An icon that when clicked will open the more menu.
 
@@ -21,7 +33,8 @@
     :on-click (fn [e]
                 (rf/dispatch [:more/toggle-show-menu])
                 (.blur (.-target e)))}
-   [:object.more-icon {:type "image/svg+xml" :data "resources/icons/more_vert-24px.svg"}
+   [:object.more-icon {:type "image/svg+xml"
+                       :data more-icon-inlined}
     "More icon"]])
 
 (defn menu-item


### PR DESCRIPTION
## What does this do?

It inlines the icon used for the more button into the program text. The original icon still remains in the resources folder.

## Motivation

Inlining the icon allows the entire app to more easily be inlined into a single html using the inliner tool in npm. This is the only icon used by the app. The only other thing needed is advanced compilation. With that addition, the app can be inlined in a single command.