### PR TITLE
fix: Compile in default model as text

### DIFF
--- a/src/inferenceql/viz/config_reader.clj
+++ b/src/inferenceql/viz/config_reader.clj
@@ -30,4 +30,4 @@
 (defmacro read
   "Loads the app config."
   []
-  (aero.core/read-config (io/resource "config.edn")))
+  `(quote ~(aero.core/read-config (io/resource "config.edn"))))


### PR DESCRIPTION
## What does this do?

This quotes the config.edn map that gets compiled into the Javascript artifact. 

## Why should we do it?

Compiling in the model as part of the config.edn breaks the build under advanced compilation.

EDN can contain list literals that look like `(1 2 3 4)`. When these are inlined into the source, Clojure will later interpret these lists as function calls and therefore cause an error. Our XCat models have some data encoded as lists, `:m :r :s :nu`, and therefore suffer from this problem. 

This can be tested by adding another edn file to `config.edn` with a list. This causes an error even under compilation with optimizations :none. 

I'm not sure why the model edn does not cause an error under compilation with optimizations :none. Perhaps something to do with lazy evaluation. 

Quoting the entire config.edn map prevents Clojure from evaluating the lists in the model as function calls, and therefore solves this issue. 