### PR TITLE
fix: Upgrade figwheel dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -35,7 +35,7 @@
                                lambdaisland/kaocha-cljs {:mvn/version "0.0-71"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}}}
            :figwheel {:extra-paths ["figwheel-target"]
-                      :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.11"}
+                      :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.13"}
                                    com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}
                       :main-opts ["-m" "figwheel.main"
                                   "-co" "build.edn:figwheel/figwheel_build_support.edn"


### PR DESCRIPTION
Motivation: It looks like there were some changes to jetty that causes figwheel to fail when launching.

```
Execution error (ArityException) at figwheel.server.jetty-websocket/async-websocket-configurator$fn$fn (jetty_websocket.clj:116).
Wrong number of args (2) passed to: ring.adapter.jetty/async-proxy-handler
```

The latest version of Figwheel fixes this.

