### PR TITLE
feat: add basic structure for Observable components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,19 @@ js-advanced: $(hot-css-resource)
 js-advanced-min: $(hot-css-resource)
 	clojure -M -m cljs.main -co $(compile-opts-advn-min) -c inferenceql.viz.core
 
+### Observable components compilation.
+
+observable-compile-opts := $(current-dir)/compiler_options/observable/build-advanced.edn
+
+.PHONY: watch-observable
+watch-observable: $(hot-css-resource)
+	clojure -M -m cljs.main -w $(src-dir) -co $(observable-compile-opts) -c inferenceql.viz.js.observable.notebook
+
+.PHONY: observable
+observable: $(hot-css-resource)
+	## Compile js-bundle for notebooks.
+	clojure -M -m cljs.main -co $(observable-compile-opts) -c inferenceql.viz.js.observable.notebook
+
 ### Supporting defs for compilation.
 
 yarn-install-opts = --no-progress --frozen-lockfile

--- a/compiler_options/observable/build-advanced.edn
+++ b/compiler_options/observable/build-advanced.edn
@@ -1,0 +1,18 @@
+{:output-to "out/index.js"
+ :output-dir "out"
+ :externs ["externs/handsontable.ext.js"
+           "externs/vega.ext.js"
+           "externs/vega-embed.ext.js"
+           "externs/vega-lite.ext.js"
+           "externs/highlight.ext.js"]
+ :browser-repl false
+ :target :bundle
+ ;; Webpack will not minify code.
+ :bundle-cmd {:default ["yarn" "run" "webpack"
+                        "--config" "compiler_options/observable/webpack.config.js"
+                        "--config-name" "un-minified"]}
+ :closure-defines {cljs.core/*global* "window"}
+ :optimizations :advanced
+ ;; Pretty code output.
+ :pseudo-names true
+ :pretty-print true}

--- a/compiler_options/observable/webpack.config.js
+++ b/compiler_options/observable/webpack.config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+
+module.exports = [
+    // Config for no minification.
+    {
+      name: 'un-minified',
+      output: {
+        path: path.resolve('./out'),
+        filename: 'main.js',
+      },
+      entry: './out/index.js',
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            enforce: "pre",
+            use: ["source-map-loader"],
+          },
+        ],
+      },
+      optimization: {
+        minimize: false,
+      }
+    }
+];
+

--- a/deps.edn
+++ b/deps.edn
@@ -16,6 +16,7 @@
         reagent-forms/reagent-forms {:mvn/version "0.5.44"}
         day8.re-frame/http-fx {:mvn/version "v0.2.0"}
         cljs-ajax/cljs-ajax {:mvn/version "0.8.1"}
+        cljs-bean/cljs-bean {:mvn/version "1.7.0"}
         cljstache/cljstache {:mvn/version "2.0.6"}
         probcomp/inferenceql.inference {:git/url "git@github.com:probcomp/inferenceql.inference.git"
                                         :sha "0f4476e9dbd4e4dafa8ecdb09f209908c97b6eaa"}

--- a/src/inferenceql/viz/js/observable/notebook.cljs
+++ b/src/inferenceql/viz/js/observable/notebook.cljs
@@ -1,0 +1,5 @@
+(ns inferenceql.viz.js.observable.notebook
+  "Build target for compiling a js-bundle for use of from an Observable notebook."
+  (:require [inferenceql.query.js]
+            [inferenceql.inference.js]
+            [inferenceql.viz.js.util]))

--- a/src/inferenceql/viz/js/util.cljs
+++ b/src/inferenceql/viz/js/util.cljs
@@ -1,0 +1,72 @@
+(ns inferenceql.viz.js.util
+  (:require [clojure.edn :as edn]
+            [clojure.pprint :refer [pprint]]
+            [goog.labs.format.csv :as goog.csv]
+            [ajax.core]
+            [ajax.edn]
+            [cljs-bean.core :refer [->clj]]
+            [medley.core :as medley]
+            [inferenceql.viz.csv :as csv]
+            [inferenceql.viz.imputation :as imputation]))
+
+(defn clj-schema
+  "Takes a js-object representing an iql schema and returns it as a clojure map.
+  This map will be properly keywordized."
+  [js-schema]
+  (medley/map-kv (fn [k v]
+                   [(keyword k) (keyword v)])
+                 (->clj js-schema)))
+
+(defn ^:export read-schema
+  "Reads and edn file with an iql schema. Returns it as a js object."
+  [schema-string]
+  (clj->js (edn/read-string schema-string)))
+
+(defn ^:export read-and-coerce-csv
+  "Takes raw csv text and returns a collection of maps for all the csv rows.
+  Values are coerced based on data types in `schema`."
+  [csv-text schema]
+  (let [csv-vecs (-> csv-text goog.csv/parse js->clj)
+        schema (clj-schema schema)]
+    (clj->js (csv/clean-csv-maps schema csv-vecs))))
+
+(defn ^:export run-remote-query
+  "Runs `query` on a iql.query server."
+  [query query-server-url]
+  (js/Promise. (fn [resolve reject]
+                 (ajax.core/ajax-request
+                  {:method :post
+                   :uri query-server-url
+                   :params query
+                   :timeout 0
+                   :format (ajax.core/text-request-format)
+                   :response-format (ajax.edn/edn-response-format)
+                   :handler (fn [[ok result]]
+                              (if ok
+                                ;; Success case.
+                                (resolve (clj->js result))
+                                ;; Failure case.
+                                (let [parse-error (get-in result [:response :instaparse/failure])
+                                      error-msg (if (some? parse-error)
+                                                  ;; Return just the parse error.
+                                                  (with-out-str (print parse-error))
+                                                  ;; Return the entire error-result as a string.
+                                                  (with-out-str (pprint result)))]
+                                  (reject (js/Error. error-msg)))))}))))
+
+(defn ^:export impute-missing-cells
+  "Returns imputed values and normalized scores for all missing values in `rows`"
+  [query-fn rows schema impute-cols num-samples]
+  (let [rows (vec (->clj rows))
+        schema (clj-schema schema)
+        query-fn #(->clj (query-fn %))
+        impute-cols (map keyword (->clj impute-cols))]
+    (clj->js (imputation/impute-missing-cells query-fn rows schema impute-cols num-samples))))
+
+(defn ^:export imputation-queries
+  "Returns a collection of queries that would be used to impute missing values in `rows`"
+  [rows schema impute-cols num-samples]
+  (let [rows (vec (->clj rows))
+        schema (clj-schema schema)
+        impute-cols (map keyword (->clj impute-cols))]
+    (clj->js (imputation/imputation-queries rows schema impute-cols num-samples))))


### PR DESCRIPTION
This adds the basic starting structure for later PRs that add UI components for use from Observable and js in general. 

Mostly this adds a new build target (ns) for compiling the app for use from Observable. 

### How to test. 

Run `make observable` to get a js-artifact with the new utils namespace and the js namespaces from other iql repos.

It easily be tried out in a new observable notebook.  