### PR TITLE
feat: Output dataset and model to console after change

### DIFF
--- a/src/inferenceql/viz/panels/upload/events.cljs
+++ b/src/inferenceql/viz/panels/upload/events.cljs
@@ -149,7 +149,10 @@
       {:fx [[:dispatch [:store/datasets datasets]]
             [:dispatch [:store/models models]]
             [:dispatch [:control/set-query-string-to-select-all]]
-            (when (seq geodata) [:dispatch [:store/geodata geodata]])]})
+            (when (seq geodata) [:dispatch [:store/geodata geodata]])
+            [:js/console-warn "Successfully read the following datasets and models."]
+            [:js/console-warn (clj->js datasets)]
+            [:js/console-warn (clj->js models)]]})
     (catch js/Error e
       {:fx [[:dispatch [:upload/read-failed (str "Error processing reads.\n" (.-stack e))]]]})))
 


### PR DESCRIPTION
## What does this do?

When a new dataset and model are added to the app via the upload panel, the cljs maps used to save this information in the app-db are output to the browser console as js objects. 

## Motivation

When the app is compiled with `:optimizations` `:advanced`, re-frame events are no longer easily interpreted on the browser console because clojurescript formatters do not work with optimized builds. Printing the dataset and model to the console as js-obects will always allow us to inspect and confirm that the dataset and model was loaded correctly. 