### PR TITLE
chore: Update iql.query

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
         probcomp/inferenceql.inference {:git/url "git@github.com:probcomp/inferenceql.inference.git"
                                         :sha "0f4476e9dbd4e4dafa8ecdb09f209908c97b6eaa"}
         probcomp/inferenceql.query {:git/url "git@github.com:probcomp/inferenceql.query.git"
-                                    :sha "e448be7baf09011ee4e2623e3ed369b292af7104"}
+                                    :sha "0241ee57e059f618ae55b2ae8822986d778b0d68"}
         probcomp/inferenceql.auto-modeling {:git/url "git@github.com:probcomp/inferenceql.auto-modeling.git"
                                             :sha "506e847f55b0379b3888e0f2b2d3fa0e52f2166e"}
         probcomp/metaprob {:git/url "https://github.com/probcomp/metaprob.git"

--- a/resources/schema.edn
+++ b/resources/schema.edn
@@ -1,1 +1,1 @@
-{:gender :categorical, :age :gaussian, :height :gaussian},
+{:gender :nominal, :age :numerical, :height :numerical},

--- a/src/inferenceql/viz/components/query/editing.cljc
+++ b/src/inferenceql/viz/components/query/editing.cljc
@@ -1,8 +1,9 @@
 (ns inferenceql.viz.components.query.editing
   "Defs related to editing inferenceql.query queries."
   (:require [instaparse.core :as insta]
-            [inferenceql.query :as query]
-            [inferenceql.query.parse-tree :as tree]
+            [inferenceql.query.lang.eval :as eval]
+            [inferenceql.query.parser :as parser]
+            [inferenceql.query.parser.tree :as tree]
             [inferenceql.viz.util :refer [coerce-bool]]
             [inferenceql.viz.components.query.util :refer [long-str make-node children zipper
                                                            seek-tag]]
@@ -21,9 +22,9 @@
   Returns:
     A query string."
   [query]
-  (let [rowid-selection-node (query/parse "rowid" :start :selection)
-        editable-col-selection-node (query/parse "editable" :start :selection)
-        label-col-selection-node (query/parse "label" :start :selection)
+  (let [rowid-selection-node (parser/parse "rowid" :start :selection)
+        editable-col-selection-node (parser/parse "editable" :start :selection)
+        label-col-selection-node (parser/parse "label" :start :selection)
 
         add-rowid (fn [select-list-node]
                     (let [selections (into [rowid-selection-node
@@ -31,16 +32,16 @@
                                             label-col-selection-node]
                                            (tree/child-nodes select-list-node))
                           selections (as-> selections $
-                                           (interleave $ (repeat ",") (repeat (query/parse " " :start :ws)))
+                                           (interleave $ (repeat ",") (repeat (parser/parse " " :start :ws)))
                                            (drop-last 2 $))]
 
                       (tree/node :select-list selections)))]
-    (-> (query/parse query)
+    (-> (parser/parse query)
         (zipper)
         (seek-tag :select-list)
         (z/edit add-rowid)
         (z/root)
-        (query/unparse))))
+        (parser/unparse))))
 
 (defn add-rowid-and-label
   "Adds rowid to the start of the select-list in a `query` string.
@@ -52,7 +53,7 @@
   Returns:
     A query string."
   [query]
-  (let [node-or-failure (query/parse query)]
+  (let [node-or-failure (parser/parse query)]
     (if (insta/failure? node-or-failure)
       query
       (add-rowid-and-label-helper query))))
@@ -60,10 +61,10 @@
 ;;; Functions related to adding ALTER and UPDATE and INSERT expressions
 ;;; for label column and new rows.
 
-(def whitespace (query/parse "\n     " :start :ws))
+(def whitespace (parser/parse "\n     " :start :ws))
 
 (defn with-sub-query-node [qs]
-  (let [qz (-> qs query/parse zipper)
+  (let [qz (-> qs parser/parse zipper)
         qz-with (seek-tag qz :with-expr)]
     (if qz-with
       (-> (z/node qz-with)
@@ -72,7 +73,7 @@
 
 ;----------------
 
-(def label-alter-node (query/parse "(ALTER data ADD label) AS data" :start :with-map-entry-expr))
+(def label-alter-node (parser/parse "(ALTER data ADD label) AS data" :start :with-map-entry-expr))
 
 (defn is-label-alter? [node]
   (let [val-expr (tree/get-node node :with-map-value-expr)
@@ -81,13 +82,13 @@
                            (z/node))
         table-name (some-> alter-expr
                            (tree/get-node-in [:table-expr :ref])
-                           (query/unparse))
+                           (parser/unparse))
         column-name (some-> alter-expr
                             (tree/get-node-in [:column-expr])
-                            (query/unparse))
+                            (parser/unparse))
 
         binding-name (-> (tree/get-node node :name)
-                         (query/unparse))]
+                         (parser/unparse))]
     (and (= table-name "data")
          (= column-name "label")
          (= binding-name "data"))))
@@ -113,10 +114,10 @@
                     :condition (reducer (tree/only-child node))
                     :equality-condition (let [selection (some-> node
                                                                 (tree/get-node :selection)
-                                                                (query/eval {}))
+                                                                (eval/eval {}))
                                               value (some-> node
                                                             (tree/get-node :value)
-                                                            (query/eval {}))]
+                                                            (eval/eval {}))]
                                           [[selection value]])
                     nil))]
     (reducer node)))
@@ -128,9 +129,9 @@
                             (z/node))
         table-name (some-> update-expr
                            (tree/get-node-in [:table-expr :ref])
-                           (query/unparse))
+                           (parser/unparse))
 
-        q-eval #(query/eval % {})
+        q-eval #(eval/eval % {})
         set-map-exprs (some-> update-expr
                               (tree/get-node-in [:set-clause :map-expr])
                               (tree/child-nodes))
@@ -140,7 +141,7 @@
                              (tree/get-node-in [:where-clause :or-condition])
                              (reduce-or-node))
         binding-name (-> (tree/get-node node :name)
-                         (query/unparse))
+                         (parser/unparse))
 
         is-label-update (and (= table-name "data")
                              (every? #(and (= "rowid" (first %)) (integer? (second %)))
@@ -160,7 +161,7 @@
                           (map #(format "rowid=%d" %))
                           (str/join " OR "))
             qs (format "(UPDATE data SET label=%s WHERE %s) AS data" label-val cond-str)]
-        (query/parse qs :start :with-map-entry-expr)))))
+        (parser/parse qs :start :with-map-entry-expr)))))
 
 (defn remove-label-update [entry-exprs]
   (remove update-node-map entry-exprs))
@@ -182,7 +183,7 @@
                   (format "%s=%s" k v))
         row-str (str/join ", " kv-strs)
         qs (format "(INSERT INTO data VALUES (%s)) AS data" row-str)]
-    (query/parse qs :start :with-map-entry-expr)))
+    (parser/parse qs :start :with-map-entry-expr)))
 
 (defn remove-new-rows [entry-exprs]
   (remove new-row-node? entry-exprs))
@@ -223,8 +224,8 @@
                             (interleave $ (repeat ",") (repeat whitespace))
                             (drop-last 2 $))
           with-map-expr (tree/node :with-map-expr entry-exprs)]
-      (str "WITH " (query/unparse with-map-expr) ":\n" (query/unparse sub-query-node)))
-    (query/unparse sub-query-node)))
+      (str "WITH " (parser/unparse with-map-expr) ":\n" (parser/unparse sub-query-node)))
+    (parser/unparse sub-query-node)))
 
 (defn handle [qz-with sub-query-node label-vals new-rows]
   (if qz-with
@@ -249,7 +250,7 @@
                             (z/replace sub-query-node)
                             (z/root))
                         sub-query-node)]
-      (query/unparse return-node))
+      (parser/unparse return-node))
     (add-new-with sub-query-node label-vals new-rows)))
 
 (defn add-edit-exprs
@@ -280,11 +281,11 @@
   Returns a query string or nil if the original query string could not be parsed."
   [cur-qs prev-qs label-vals new-rows]
   (let [cur-qs (str/trim cur-qs)]
-    (when-not (insta/failure? (query/parse cur-qs))
+    (when-not (insta/failure? (parser/parse cur-qs))
       ;; Edit the query.
-      (let [prev-qz (some-> prev-qs query/parse zipper)
+      (let [prev-qz (some-> prev-qs parser/parse zipper)
             prev-qz-with (some-> prev-qz (seek-tag :with-expr))
-            cur-qz (some-> cur-qs query/parse zipper)
+            cur-qz (some-> cur-qs parser/parse zipper)
             cur-qz-with (some-> cur-qz (seek-tag :with-expr))
             sub-query-node (with-sub-query-node cur-qs)]
         (if prev-qz-with
@@ -314,7 +315,7 @@
                              (recur rs new-query))
                            query))
                        column-incorp)]
-    (query/parse row-incorps :start :model-expr)))
+    (parser/parse row-incorps :start :model-expr)))
 
 (defn add-incorp-node [node label-vals editable-rows]
   (let [loc (zipper node)
@@ -357,11 +358,11 @@
   Returns a query string or nil if the original query string could not be parsed."
   [query-string label-vals editable-rows]
   (let [query-string (str/trim query-string)]
-    (when-not (insta/failure? (query/parse query-string))
+    (when-not (insta/failure? (parser/parse query-string))
       ;; Edit the query.
-      (loop [qz (-> query-string query/parse zipper)]
+      (loop [qz (-> query-string parser/parse zipper)]
         (if (z/end? qz)
-          (-> qz z/node query/unparse)
+          (-> qz z/node parser/unparse)
           (if-let [qz-under (seek-tag qz :under-clause)]
             (recur (z/next (z/edit qz-under add-incorp-node label-vals editable-rows)))
             (recur (z/next qz))))))))

--- a/src/inferenceql/viz/components/query/subs.cljs
+++ b/src/inferenceql/viz/components/query/subs.cljs
@@ -80,7 +80,7 @@
   "Returns a schema for the query whose results are currently displayed.
 
   This schema includes new columns that have been generated and columns that have been renamed.
-  Returns: {:column-name-1 :gaussian, :column-name-2 :categorical, ...}"
+  Returns: {:column-name-1 :numerical, :column-name-2 :nominal, ...}"
   [db _]
   (get-in db [:query-component :schema]))
 (rf/reg-sub :query/schema

--- a/src/inferenceql/viz/components/query/util.cljc
+++ b/src/inferenceql/viz/components/query/util.cljc
@@ -1,8 +1,8 @@
 (ns inferenceql.viz.components.query.util
   "Utility functions for manipulating and extracting info from iql.query parse trees."
   (:require [instaparse.core :as insta]
-            [inferenceql.query :as query]
-            [inferenceql.query.parse-tree :as tree]
+            [inferenceql.query.parser :as parser]
+            [inferenceql.query.parser.tree :as tree]
             [clojure.zip :as z]))
 
 ;;; Various utility functions related to queries.
@@ -75,7 +75,7 @@
     (when new-name
       {:detail-type :new-column-schema
        :name (keyword (tree/only-child new-name))
-       :stat-type :gaussian})))
+       :stat-type :numerical})))
 
 (defn- column-details-for-selection
   "Returns a column-detail map for this `selection` portion of the parse tree."
@@ -96,7 +96,7 @@
   Returns a sequences of column-detail maps, each map representing either a column rename or
   schema info for a new column."
   [query]
-  (keep column-details-for-selection (get-selection-list (query/parse query))))
+  (keep column-details-for-selection (get-selection-list (parser/parse query))))
 
 (defn column-renames
   "Returns a map of columns that have been renamed as a result of executing the last query.
@@ -112,7 +112,7 @@
 (defn new-columns-schema
   "Returns a schema for new columns that were created as a result of executing the last query.
 
-  Returns: {:new-column-name :gaussian, ...}"
+  Returns: {:new-column-name :numerical, ...}"
   [column-details]
   (->> column-details
     (filter #(= (:detail-type %) :new-column-schema))
@@ -124,7 +124,7 @@
 (defn virtual-data?
   "Returns whether the resultset of `query` represents virtual data."
   [query]
-  (let [node-or-failure (query/parse query)]
+  (let [node-or-failure (parser/parse query)]
     (when-not (insta/failure? node-or-failure)
       (some? (some-> node-or-failure
                      zipper

--- a/src/inferenceql/viz/components/store/db.cljs
+++ b/src/inferenceql/viz/components/store/db.cljs
@@ -60,7 +60,7 @@
 (s/def ::rows (s/coll-of ::row))
 (s/def ::row (s/map-of ::column-name any?))
 (s/def ::schema (s/map-of ::column-name ::stat-type))
-(s/def ::stat-type #{:gaussian :categorical})
+(s/def ::stat-type #{:numerical :nominal})
 (s/def ::model-name keyword?)
 ;; This is the model used to generate samples for simulation plots when a
 ;; single cell is selected in the table.

--- a/src/inferenceql/viz/panels/table/handsontable_events.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable_events.cljs
@@ -97,7 +97,7 @@
                       (assert (or (= col :label) editable))
 
                       (cond
-                        (= type :gaussian)
+                        (= type :numerical)
                         ;; Try to cast.
                         (let [new-val (edn/read-string new-val)]
                           (if (or (number? new-val) (nil? new-val))
@@ -112,7 +112,7 @@
                                   (update :errors conj error)
                                   (update :change-ids-to-cancel conj i)))))
 
-                        (= type :categorical)
+                        (= type :nominal)
                         ;; Check if valid category-value
                         (let [categories (get categories col)]
                           (if (or (contains? categories new-val) (string/blank? new-val))

--- a/src/inferenceql/viz/panels/viz/vega.cljs
+++ b/src/inferenceql/viz/panels/viz/vega.cljs
@@ -75,8 +75,8 @@
 
           :else
           ;; Mapping from multi-mix stat-types to vega-lite data-types.
-          (let [mapping {:gaussian "quantitative"
-                         :categorical "nominal"}]
+          (let [mapping {:numerical "quantitative"
+                         :nominal "nominal"}]
             (get mapping (get schema col-name))))))
 
 (defn should-bin?


### PR DESCRIPTION
## What does this do? 

* Updates the iql.query dep to the latest version.

* Updates the format of the schema, to use `:nominal` and `:numerical` as datatypes (now required by recent changes in iql.query). 
The use of datatypes has been updated everywhere and the schema of the compiled in dataset has been updated.

* Update the use of various iql.query defs that have been moved in recent PR's.

