### PR TITLE
refactor: move webpack config

### DIFF
--- a/compiler_options/app/build-advanced-min.edn
+++ b/compiler_options/app/build-advanced-min.edn
@@ -8,6 +8,8 @@
  :browser-repl false
  :target :bundle
  ;; Webpack will minify code.
- :bundle-cmd {:default ["yarn" "run" "webpack" "--config-name" "minified"]}
+ :bundle-cmd {:default ["yarn" "run" "webpack"
+                        "--config" "compiler_options/app/webpack.config.js"
+                        "--config-name" "minified"]}
  :closure-defines {cljs.core/*global* "window"}
  :optimizations :advanced}

--- a/compiler_options/app/build-advanced.edn
+++ b/compiler_options/app/build-advanced.edn
@@ -8,7 +8,9 @@
  :browser-repl false
  :target :bundle
  ;; Webpack will not minify code.
- :bundle-cmd {:default ["yarn" "run" "webpack" "--config-name" "un-minified"]}
+ :bundle-cmd {:default ["yarn" "run" "webpack"
+                        "--config" "compiler_options/app/webpack.config.js"
+                        "--config-name" "un-minified"]}
  :closure-defines {cljs.core/*global* "window"}
  :optimizations :advanced
  ;; Pretty code output.

--- a/compiler_options/app/build.edn
+++ b/compiler_options/app/build.edn
@@ -8,7 +8,9 @@
  :browser-repl false
  :target :bundle
  ;; Webpack will not minify code.
- :bundle-cmd {:none ["yarn" "run" "webpack" "--mode=development" "--config-name" "un-minified"]}
+ :bundle-cmd {:none ["yarn" "run" "webpack" "--mode=development"
+                     "--config" "compiler_options/app/webpack.config.js"
+                     "--config-name" "un-minified"]}
  :closure-defines {cljs.core/*global* "window"}
  ;; Cljs Chrome dev-tools.
  :preloads [devtools.preload]

--- a/compiler_options/app/webpack.config.js
+++ b/compiler_options/app/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = [
     {
       name: 'un-minified',
       output: {
-        path: path.resolve(__dirname, 'out'),
+        path: path.resolve('./out'),
         filename: 'main.js',
       },
       entry: './out/index.js',
@@ -27,7 +27,7 @@ module.exports = [
     {
       name: 'minified',
       output: {
-        path: path.resolve(__dirname, 'out'),
+        path: path.resolve('./out'),
         filename: 'main.js',
       },
       entry: './out/index.js',


### PR DESCRIPTION
This moves the current webpack config file into the same directory as compiler_options files for various app builds. 

#### Motivation 

In an upcoming PR there will be an other webpack config file specific to the figwheel build of the app. 