### PR TITLE
fix: de-select after invalid selection

### DIFF
--- a/src/inferenceql/viz/panels/table/handsontable.cljs
+++ b/src/inferenceql/viz/panels/table/handsontable.cljs
@@ -57,6 +57,12 @@
                                        (js->clj (.getSelected hot))])
                          true))
 
+                     :hot/after-deselect
+                     (fn [_]
+                       (fn []
+                         (rf/dispatch [:hot/after-deselect])
+                         true))
+
                      :hot/after-on-cell-mouse-down
                      (fn [_]
                        (fn [mouse-event _coords _TD]


### PR DESCRIPTION
This fixes the situation where the user makes a disallowed selection in handsontable (selects more than two columns, etc) and all cells are automatically de-selected. Previously cells in the table were not being de-selected after the disallowed selection. 

## Motivation 

To return the app the expected behavior . 