### PR TITLE
refactor: no longer include `:row-at-selection-start` in selection layers

### DIFF
--- a/src/inferenceql/viz/panels/table/selections.cljs
+++ b/src/inferenceql/viz/panels/table/selections.cljs
@@ -53,12 +53,6 @@
     ;; Merging the row-wise data for each selection layer.
     (apply mapv merge data-by-layer)))
 
-(defn get-row-at-selection-start
-  "Returns the row in `rows` indexed by the start of the last selection rectangle in `coords`."
-  [coords rows]
-  (let [[r1 _c1 _r2 _c2] (last coords)]
-    (nth rows r1)))
-
 (defn valid-coords?
   "Checks whether the bounds of the selection rectangles in `coords` fit the data table size."
   [coords table-width table-height]
@@ -78,8 +72,7 @@
   (when (valid-coords? coords (count headers) (count rows))
     {:coords coords
      :selected-columns (get-selected-columns coords headers)
-     :selections (get-selections coords headers rows)
-     :row-at-selection-start (get-row-at-selection-start coords rows)}))
+     :selections (get-selections coords headers rows)}))
 
 (defn selection-layers
   "Merges in data pertaining to the selection-layer-coords

--- a/src/inferenceql/viz/panels/viz/vega.cljs
+++ b/src/inferenceql/viz/panels/viz/vega.cljs
@@ -423,8 +423,7 @@
   (let [vega-type (vega-type-fn schema)
         {layer-name :id
          selections :selections
-         cols :selected-columns
-         row :row-at-selection-start} selection-layer]
+         cols :selected-columns} selection-layer]
     ;; Only produce a spec when we can find a vega-type for all selected columns
     ;; except the geo-id-col which we handle specially.
     (when (every? some? (map vega-type (remove #{geo-id-col} cols)))
@@ -432,7 +431,7 @@
                        (gen-choropleth geodata geo-id-col selections cols vega-type)
 
                        (simulatable? selections cols simulatable-cols)
-                       (gen-simulate-plot (first cols) row (name layer-name) vega-type)
+                       (gen-simulate-plot (first cols) (first selections) (name layer-name) vega-type)
 
                        (= 1 (count cols)) ; One column selected.
                        (gen-histogram (first cols) selections vega-type)


### PR DESCRIPTION
Simplify selections layers subscription by no longer including the `:row-at-selection-start` key. This data can be obtained more simply.

### Motivation

Cleanup and simplicity