### PR TITLE
refactor: make various defs public

### DIFF
--- a/src/inferenceql/viz/panels/table/views.cljs
+++ b/src/inferenceql/viz/panels/table/views.cljs
@@ -22,7 +22,7 @@
         num-cols (count columns)]
     (every? #(< % num-cols) col-nums-refed)))
 
-(defn- update-hot!
+(defn update-hot!
   "A helper function for updating the settings in a handsontable."
   [hot-instance new-settings current-selection]
   (let [;; Stores whether settings that determine the data displayed have changed.

--- a/src/inferenceql/viz/panels/viz/views.cljs
+++ b/src/inferenceql/viz/panels/viz/views.cljs
@@ -12,7 +12,7 @@
 (def ^:private log-level-debug
   (.-Warn yarn-vega))
 
-(def ^:private default-vega-embed-options
+(def default-vega-embed-options
   {:renderer "svg"
    :mode "vega-lite"
    :logLevel log-level-default


### PR DESCRIPTION
Makes a couple private defs public (helper functions related to handsontable and vega-lite). 

### Motivation 

These will be used by similar simplified components in an upcoming PR for UI components for Observable notebooks. 