### PR TITLE
fix: coerce schema to use keywords

### DIFF
--- a/src/inferenceql/viz/components/store/db.cljs
+++ b/src/inferenceql/viz/components/store/db.cljs
@@ -4,13 +4,17 @@
   models and geodata are stored."
   (:require [clojure.spec.alpha :as s]
             [clojure.edn :as edn]
+            [medley.core :as medley]
             [inferenceql.viz.config :as config]
             [inferenceql.viz.csv :refer [clean-csv-maps]]
+            [inferenceql.viz.util :refer [keywordize-kv]]
             [inferenceql.inference.gpm :as gpm]))
 
 ;;; Compiled-in elements to store
 
-(def compiled-in-schema (get config/config :schema))
+(def compiled-in-schema
+  ;; Coerce schema to contain columns names and datatyptes as keywords.
+  (keywordize-kv (get config/config :schema)))
 
 (def compiled-in-dataset
   (clean-csv-maps (get config/config :schema)

--- a/src/inferenceql/viz/panels/upload/events.cljs
+++ b/src/inferenceql/viz/panels/upload/events.cljs
@@ -6,6 +6,7 @@
             [medley.core :refer [index-by map-vals find-first]]
             [inferenceql.viz.events.interceptors :refer [event-interceptors]]
             [inferenceql.viz.csv :refer [clean-csv-maps]]
+            [inferenceql.viz.util :refer [keywordize-kv]]
             [inferenceql.auto-modeling.bayesdb-import :as bayesdb-import]
             [inferenceql.inference.gpm :as gpm]))
 
@@ -110,8 +111,11 @@
                                (let [schema-read (find-first #(= (:kind %) :schema) read-pair)
                                      dataset-read (find-first #(= (:kind %) :dataset) read-pair)
 
-                                     schema (edn/read-string (:raw-data schema-read))
-                                     csv-data (csv/parse (:raw-data dataset-read))
+                                     schema  (-> (:raw-data schema-read)
+                                                 edn/read-string
+                                                 keywordize-kv)
+                                     csv-data (-> (:raw-data dataset-read)
+                                                  csv/parse)
                                      rows (clean-csv-maps schema csv-data)]
 
                                  (merge (:details dataset-read)

--- a/src/inferenceql/viz/util.cljc
+++ b/src/inferenceql/viz/util.cljc
@@ -33,3 +33,8 @@
     "false" false
     "f" false
     nil))
+
+(defn keywordize-kv [a-map]
+  "Returns `a-map` with both keys and values keywordized."
+  (medley/map-kv (fn [col type] [(keyword col) (keyword type)])
+                 a-map))


### PR DESCRIPTION
This coerces the keys and values in the schema to keywords. This applies to both the compiled-in schema and any schema that gets uploaded into the app via the upload panel. 

### Motivation 

The `schema.edn` output by iql.auto-modeling uses strings as keys and keywords as values. It is expected that this schema should work with the iql app. Before this change, it would break the iql.viz due to the string keys. 

example `schema.edn` from auto-modeling.

```clojure
{"ld4" :numerical, "ld2" :numerical, "ld5" :numerical, "s4" :numerical, "s3" :numerical, "p2" :numerical, "ld3" :numerical, "p1" :numerical, "ld1" :numerical, "p3" :numerical, "s1" :numerical, "s2" :numerical, "p5" :numerical, "p4" :numerical, "s5" :numerical}
```