### PR TITLE
fix: default settings in handsontable js component

### DIFF
--- a/src/inferenceql/viz/js/components/table/views.cljs
+++ b/src/inferenceql/viz/js/components/table/views.cljs
@@ -10,9 +10,9 @@
 
 (def observable-hot-settings
   (-> default-hot-settings
-      (dissoc :colHeaders :columns :dropdownMenu)
-      (assoc :height "auto")
-      (assoc :width "auto")))
+      (update :settings dissoc :colHeaders :columns :dropdownMenu :filters)
+      (assoc-in [:settings :height] "auto")
+      (assoc-in [:settings :width] "auto")))
 
 (defn handsontable-base
   "A simplified version of a reagent component for Handsontable."


### PR DESCRIPTION
## What does this do?

This fixes the default settings for the Handsontable standalone UI component. See inline comments for details. 