### PR TITLE
fix: js-prog template for multiple views

### DIFF
--- a/src/inferenceql/viz/panels/jsmodel/multimix.cljc
+++ b/src/inferenceql/viz/panels/jsmodel/multimix.cljc
@@ -8,7 +8,9 @@
 (defn trunc
   "Truncate number to 3 decimals places."
   [n]
-  (format "%.3f" n))
+  (if (integer? n)
+    (str n)
+    (format "%.3f" n)))
 
 (def range-1
   "Infinite list of natural numbers."
@@ -75,7 +77,7 @@
          :weights (->> (get categorical-col-vals param-key)
                        (map param-vals)
                        (map trunc)
-                       (str/join ","))}
+                       (str/join ", "))}
 
         false ;; Guassian variable.
         {:name (name param-key)

--- a/test/inferenceql/viz/panels/jsmodel/multimix_test.cljc
+++ b/test/inferenceql/viz/panels/jsmodel/multimix_test.cljc
@@ -4,7 +4,7 @@
 
 (def spec
   "A generic multimix model spec."
-  {:vars {:gender :categorical, :height :gaussian, :age :gaussian},
+  {:vars {:gender :categorical, :height :gaussian, :age :gaussian :fav-color :categorical},
    :views [;; view 1
            [{:probability 0.35,
              :parameters {:height {:mu 160, :sigma 0.7},
@@ -14,49 +14,55 @@
                           :gender {"female" 0.19, "male" 0.81},}}]
            ;; view 2
            [{:probability 1,
-             :parameters {:age {:mu 40, :sigma 1},}}]]})
+             :parameters {:age {:mu 40, :sigma 1},
+                          :fav-color {"blue" 0.60 "green" 0.40}}}]]})
 
 (def categories-section-expected
   "Expected test data"
-  [{:name "gender", :values "\"female\", \"male\""}])
+  [{:name "gender", :values "\"female\", \"male\""}
+   {:name "fav-color", :values "\"blue\", \"green\""}])
 
 (def views-section-expected
   "Expected test data"
   [;; view 1
    {:num 1
-    :cluster-probs "0.35, 0.65",
+    :cluster-probs "0.350, 0.650",
     :clusters [{:first true,
                 :num 1,
                 :parameters [{:gaussian true,
                               :last false
-                              :mu 160,
+                              :mu "160",
                               :name "height",
-                              :sigma 0.7}
+                              :sigma "0.700"}
                              {:categorical true,
                               :last true,
                               :name "gender",
-                              :weights "0.89, 0.11"}]}
+                              :weights "0.890, 0.110"}]}
                {:first false,
                 :num 2,
                 :parameters [{:gaussian true,
                               :last false
-                              :mu 176,
+                              :mu "176",
                               :name "height",
-                              :sigma 0.6}
+                              :sigma "0.600"}
                              {:categorical true,
                               :last true,
                               :name "gender",
-                              :weights "0.19, 0.81"}]}]}
+                              :weights "0.190, 0.810"}]}]}
    ;; view 2
    {:num 2
     :cluster-probs "1",
     :clusters [{:first true,
                 :num 1,
                 :parameters [{:gaussian true,
-                              :last true,
-                              :mu 40,
+                              :last false,
+                              :mu "40",
                               :name "age",
-                              :sigma 1}]}]}])
+                              :sigma "1"}
+                             {:categorical true,
+                              :last true,
+                              :name "fav-color",
+                              :weights "0.600, 0.400"}]}]}])
 
 (def model-section-expected
   "Expected test data"


### PR DESCRIPTION
## What does this do?

* The template generating code for producing js-model exports would break when given a multimix model with multiple views. This fix that. 

* It also truncates all parameters to 3 decimal places.

## How to test?

Run `bin/kaocha` as there are tests for this. 