### PR TITLE
chore: update figwheel dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -35,6 +35,6 @@
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
                                com.lambdaisland/kaocha-cljs {:mvn/version "1.0.93"}}}
            :figwheel {:extra-paths ["figwheel-target"]
-                      :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.13"}
+                      :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.14"}
                                    com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}}}
            :reframe-10x {:extra-deps {day8.re-frame/re-frame-10x {:mvn/version "1.1.11"}}}}}


### PR DESCRIPTION
motivation: this fixes the `make figwheel` command on M1 macs. 