### PR TITLE
fix: error message in mini-app js component

### DIFF
--- a/src/inferenceql/viz/js/components/mini_app/views.cljs
+++ b/src/inferenceql/viz/js/components/mini_app/views.cljs
@@ -15,7 +15,7 @@
                       (let [r (<p! (query-fn @input-text))]
                         (success r))
                       (catch js/Error err
-                        (failure (with-out-str (print (.-message (ex-cause err))))))
+                        (failure (with-out-str (print (str (ex-cause err))))))
                       (finally (reset! running false))))]
     (fn []
       [:div#toolbar


### PR DESCRIPTION
This is a quick fix to properly show errors with query parsing in the iql mini-app component exposed to Javascript consumers (and Observable users).

It's unclear why the previous method stopped working. However this fix again shows errors although with some excess information. This is at least an improvement. 

<img width="1276" alt="Screen Shot 2021-12-21 at 5 46 17 PM" src="https://user-images.githubusercontent.com/362292/147011867-fb65a076-36fc-4c09-8b00-9b94c53cb35d.png">
